### PR TITLE
DRAFT - adds missing MMG to Mudskipper

### DIFF
--- a/The_United_States.cat
+++ b/The_United_States.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2367-9a00-5a8f-f0d2" name="The_United_States" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="9a47-ac76-5252-54d0" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2367-9a00-5a8f-f0d2" name="The_United_States" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="9a47-ac76-5252-54d0" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <publications>
     <publication id="2367-9a00-pubN65551" name="Konflikt 47 Rules"/>
     <publication id="2367-9a00-pubN65638" name="Konflikt 47: Defiance"/>
@@ -15,130 +15,130 @@
       <categoryLinks>
         <categoryLink id="8fdb-06eb-ef99-b191" name="Commander" hidden="false" targetId="fb1a-cb93-a427-51cf" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7374-66aa-bf16-b90d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b555-4b44-53d3-071e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7374-66aa-bf16-b90d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b555-4b44-53d3-071e" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="77ec-4994-3ad0-16ce" name="Infantry Squad" hidden="false" targetId="360a-867e-e501-63b2" primary="false">
+        <categoryLink id="77ec-4994-3ad0-16ce" name="Infantry Squads" hidden="false" targetId="360a-867e-e501-63b2" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73cb-da92-bd64-cbc1" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="787c-fb7f-3820-d5ab" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73cb-da92-bd64-cbc1" type="min"/>
+            <constraint field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="787c-fb7f-3820-d5ab" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="b9d0-b955-6170-d6fb" name="Senior Officer" hidden="false" targetId="b14d-60bd-51cb-1c49" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c91-fafe-a56b-5cc3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c91-fafe-a56b-5cc3" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="0ad6-312e-033f-c409" name="Medic" hidden="false" targetId="64b3-a04b-d6d0-add2" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb63-daba-6d11-0218" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb63-daba-6d11-0218" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="cedb-bbce-8734-b1d1" name="Forward Observer" hidden="false" targetId="c048-dfb7-583d-2e79" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d31e-0f8b-3cdd-b90d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d31e-0f8b-3cdd-b90d" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="6a62-9289-59dd-c10f" name="Machine Gun Team" hidden="false" targetId="1688-881c-5284-0be8" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1054-4243-305d-fc46" type="max"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1054-4243-305d-fc46" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="61a3-f0ed-d0ea-1d4e" name="Mortar Team" hidden="false" targetId="d9b6-6214-f7d0-e6f4" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4715-ae5e-6e64-cd37" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4715-ae5e-6e64-cd37" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="93c3-be26-37f2-8edf" name="Sniper Team" hidden="false" targetId="6077-3929-61c8-5eb7" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3759-92be-de01-d61e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3759-92be-de01-d61e" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="e921-a86e-e357-2ddc" name="Flamethrower Team" hidden="false" targetId="c5aa-dfef-70b7-726b" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bcc-9d07-e7ae-f2e9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bcc-9d07-e7ae-f2e9" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="2cf9-a9d7-4ef4-cca8" name="Anti-Tank Team" hidden="false" targetId="c04e-ff05-f7cb-ae9b" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a90a-cf68-ddd6-aa38" type="max"/>
+            <constraint field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a90a-cf68-ddd6-aa38" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="53b0-d094-f80b-440c" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62f0-1d68-eaa4-c5f3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62f0-1d68-eaa4-c5f3" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="870c-4b0d-6090-71a6" name="Armored Cars, Scout and Light Walkers" hidden="false" targetId="00b4-e9d7-e705-1f53" primary="false">
           <modifiers>
-            <modifier type="increment" field="36e4-53b4-9ed6-f89a" value="1.0">
+            <modifier type="increment" field="36e4-53b4-9ed6-f89a" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2223-b0fe-f380-0b0d" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2161-15bd-f8a3-750b" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ef-18ac-e4b0-39cf" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2223-b0fe-f380-0b0d" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2161-15bd-f8a3-750b" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ef-18ac-e4b0-39cf" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36e4-53b4-9ed6-f89a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36e4-53b4-9ed6-f89a" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="8341-3d33-bacd-0e3f" name="Transports" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="false">
           <modifiers>
-            <modifier type="increment" field="53bd-86c6-3066-c4b5" value="1.0">
+            <modifier type="increment" field="53bd-86c6-3066-c4b5" value="1">
               <repeats>
-                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53bd-86c6-3066-c4b5" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53bd-86c6-3066-c4b5" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="f936-087d-9f7b-763a" name="Tows" hidden="false" targetId="f3c7-5675-463e-b566" primary="false">
           <modifiers>
-            <modifier type="increment" field="943d-e33a-9403-c740" value="1.0">
+            <modifier type="increment" field="943d-e33a-9403-c740" value="1">
               <repeats>
-                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5056-7005-6edc-4816" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5056-7005-6edc-4816" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="943d-e33a-9403-c740" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="943d-e33a-9403-c740" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="66af-3672-add5-dfdb" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false">
           <modifiers>
-            <modifier type="increment" field="f000-bb20-7680-ddb8" value="1.0">
+            <modifier type="increment" field="f000-bb20-7680-ddb8" value="1">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00b4-e9d7-e705-1f53" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00b4-e9d7-e705-1f53" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f000-bb20-7680-ddb8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f000-bb20-7680-ddb8" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="cf87-087b-fab5-13c7" name="Infantry Support Squads" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="false"/>
         <categoryLink id="6f84-dce0-f23b-f2dd" name="Headquarters" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="false"/>
         <categoryLink id="22ea-7817-3079-0adf" name="Walkers" hidden="false" targetId="2161-15bd-f8a3-750b" primary="false"/>
-        <categoryLink id="8c73-f132-14fb-cabf" name="Armored Officer" hidden="false" targetId="31fe-b631-5c13-5493" primary="false">
+        <categoryLink id="8c73-f132-14fb-cabf" name="US Armored Officer" hidden="false" targetId="31fe-b631-5c13-5493" primary="false">
           <modifiers>
-            <modifier type="set" field="c80a-1581-6fce-c342" value="1.0">
+            <modifier type="set" field="c80a-1581-6fce-c342" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9cf3-0bc0-7974-b411" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9cf3-0bc0-7974-b411" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c80a-1581-6fce-c342" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c80a-1581-6fce-c342" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="9da7-ea4a-c4b9-b4de" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="false"/>
@@ -149,122 +149,122 @@
       <categoryLinks>
         <categoryLink id="4d7d-42cc-bdca-9942" name="Commander" hidden="false" targetId="fb1a-cb93-a427-51cf" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6504-10f0-ee00-8b40" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b516-521c-45be-fbe7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6504-10f0-ee00-8b40" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b516-521c-45be-fbe7" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d07b-faa7-a6e8-0b66" name="Senior Officer" hidden="false" targetId="b14d-60bd-51cb-1c49" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5eb-6572-6c9c-7d3a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5eb-6572-6c9c-7d3a" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="6be6-c102-472c-326e" name="Medic" hidden="false" targetId="64b3-a04b-d6d0-add2" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b28e-8735-ffe9-2f79" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b28e-8735-ffe9-2f79" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="508b-7919-2107-8a09" name="Forward Artillery Observer" hidden="false" targetId="1f3d-c608-4cb7-2ec0" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebe2-c244-0e74-8d7d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebe2-c244-0e74-8d7d" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="e8d9-525e-3b8c-b53f" name="Machine Gun Team" hidden="false" targetId="1688-881c-5284-0be8" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95b8-a422-dd18-6346" type="max"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95b8-a422-dd18-6346" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="9207-9c3b-f419-df44" name="Light and Medium Mortar Team" hidden="false" targetId="9e4b-337b-7b0a-20f2" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72e6-1127-a1d5-e868" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72e6-1127-a1d5-e868" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="747a-b387-6abf-d54e" name="Sniper Team" hidden="false" targetId="6077-3929-61c8-5eb7" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56e6-b2a4-d23e-54d7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56e6-b2a4-d23e-54d7" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="0b5a-8f6e-9f95-a4f5" name="Flamethrower Team" hidden="false" targetId="c5aa-dfef-70b7-726b" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9074-ff3e-1a17-da53" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9074-ff3e-1a17-da53" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="cc26-a327-bb16-4b8e" name="Anti-Tank Team" hidden="false" targetId="c04e-ff05-f7cb-ae9b" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="993c-3f8d-b472-9c84" type="max"/>
+            <constraint field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="993c-3f8d-b472-9c84" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="e762-4d28-5df7-5846" name="Light Artillery, Light and Medium AT Guns" hidden="false" targetId="1842-7654-2d60-c182" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42ba-6846-27c0-ab30" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42ba-6846-27c0-ab30" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="6ba1-b7c5-3f0d-1feb" name="Armored Cars, Scout and Light Walkers" hidden="false" targetId="00b4-e9d7-e705-1f53" primary="false">
           <modifiers>
-            <modifier type="increment" field="acb5-c272-33a8-530a" value="1.0">
+            <modifier type="increment" field="acb5-c272-33a8-530a" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2223-b0fe-f380-0b0d" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2161-15bd-f8a3-750b" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ef-18ac-e4b0-39cf" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2223-b0fe-f380-0b0d" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2161-15bd-f8a3-750b" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ef-18ac-e4b0-39cf" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acb5-c272-33a8-530a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acb5-c272-33a8-530a" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="2c88-e25d-d029-46a6" name="Transports" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="false">
           <modifiers>
-            <modifier type="increment" field="ae23-218e-1591-5316" value="1.0">
+            <modifier type="increment" field="ae23-218e-1591-5316" value="1">
               <repeats>
-                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae23-218e-1591-5316" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae23-218e-1591-5316" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="afa5-8587-1d0a-f122" name="Tows" hidden="false" targetId="f3c7-5675-463e-b566" primary="false">
           <modifiers>
-            <modifier type="increment" field="fd4a-d690-2735-a599" value="1.0">
+            <modifier type="increment" field="fd4a-d690-2735-a599" value="1">
               <repeats>
-                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5056-7005-6edc-4816" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5056-7005-6edc-4816" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd4a-d690-2735-a599" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd4a-d690-2735-a599" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="090e-a7e3-99d0-e3cd" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false">
           <modifiers>
-            <modifier type="increment" field="5064-a61a-40b4-9511" value="1.0">
+            <modifier type="increment" field="5064-a61a-40b4-9511" value="1">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00b4-e9d7-e705-1f53" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00b4-e9d7-e705-1f53" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5064-a61a-40b4-9511" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5064-a61a-40b4-9511" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="201f-0929-e5f8-8e3c" name="Forward Air Observer" hidden="false" targetId="1a15-5468-fc36-e232" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3013-15b0-0ca1-dcca" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3013-15b0-0ca1-dcca" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="9478-3f59-4ce1-9677" name="Headquarters" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="false"/>
         <categoryLink id="597f-6f25-60af-890b" name="Infantry Support Squads" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="false"/>
         <categoryLink id="6e84-45c7-b915-a256" name="Infantry Squads" hidden="false" targetId="360a-867e-e501-63b2" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ad3-2348-d370-b04d" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05f0-a297-f2b2-5959" type="max"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ad3-2348-d370-b04d" type="min"/>
+            <constraint field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05f0-a297-f2b2-5959" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="2c80-14c1-3690-c0e4" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="false"/>
@@ -272,26 +272,26 @@
         <categoryLink id="1be0-02e7-d43e-107a" name="Walkers" hidden="false" targetId="2161-15bd-f8a3-750b" primary="false"/>
         <categoryLink id="5931-326b-2b02-7bba" name="Airborne, Firefly, Paragon, and Paragon Support squads" hidden="false" targetId="3d5f-584d-0742-f29d" primary="false">
           <modifiers>
-            <modifier type="increment" field="8ebb-35dc-ee09-c378" value="1.0">
+            <modifier type="increment" field="8ebb-35dc-ee09-c378" value="1">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ebb-35dc-ee09-c378" type="min"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ebb-35dc-ee09-c378" type="min"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="c2d9-4bef-33a7-36a4" name="Armored Officer" hidden="false" targetId="31fe-b631-5c13-5493" primary="false">
+        <categoryLink id="c2d9-4bef-33a7-36a4" name="US Armored Officer" hidden="false" targetId="31fe-b631-5c13-5493" primary="false">
           <modifiers>
-            <modifier type="set" field="7356-a505-513e-8568" value="1.0">
+            <modifier type="set" field="7356-a505-513e-8568" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9cf3-0bc0-7974-b411" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9cf3-0bc0-7974-b411" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7356-a505-513e-8568" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7356-a505-513e-8568" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3c7e-f7fe-418c-9798" name="Armoured Cars and Anti-Aircraft Vehicles" hidden="false" targetId="5c3c-21b9-e716-a67e" primary="false"/>
@@ -301,100 +301,100 @@
       <categoryLinks>
         <categoryLink id="0246-6368-0333-157f" name="Commander" hidden="false" targetId="fb1a-cb93-a427-51cf" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0258-cecc-9c3a-a7ba" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35df-ca48-329e-39bd" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0258-cecc-9c3a-a7ba" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35df-ca48-329e-39bd" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="72d7-b15c-9d97-8080" name="Infantry Squads" hidden="false" targetId="360a-867e-e501-63b2" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1536-e012-db50-d225" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db93-0339-dbdd-f641" type="max"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1536-e012-db50-d225" type="min"/>
+            <constraint field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db93-0339-dbdd-f641" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="fcd8-4069-5b2a-a7ab" name="Senior Officer" hidden="false" targetId="b14d-60bd-51cb-1c49" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b9e-2aec-1a39-8a14" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b9e-2aec-1a39-8a14" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="f85a-c44d-681b-e40f" name="Medic" hidden="false" targetId="64b3-a04b-d6d0-add2" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="820b-299a-2ce0-8bf9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="820b-299a-2ce0-8bf9" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="ea94-c60a-8db9-11ec" name="Machine Gun Team" hidden="false" targetId="1688-881c-5284-0be8" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31be-273e-4e2e-0bb9" type="max"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31be-273e-4e2e-0bb9" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="dd9e-906a-148b-e691" name="Sniper Team" hidden="false" targetId="6077-3929-61c8-5eb7" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8f5-c364-2f71-ec5b" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8f5-c364-2f71-ec5b" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="a1aa-6d25-a787-2a86" name="Flamethrower Team" hidden="false" targetId="c5aa-dfef-70b7-726b" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3f8-d9ac-bfb0-2046" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3f8-d9ac-bfb0-2046" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="1965-6eb2-32f0-2641" name="Anti-Tank Team" hidden="false" targetId="c04e-ff05-f7cb-ae9b" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cb6-8fd2-f81a-a8ac" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cb6-8fd2-f81a-a8ac" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="ab28-d1ab-5272-6587" name="Armored Cars, Scout and Light Walkers" hidden="false" targetId="00b4-e9d7-e705-1f53" primary="false">
           <modifiers>
-            <modifier type="increment" field="b13b-5f1c-1c0b-1636" value="1.0">
+            <modifier type="increment" field="b13b-5f1c-1c0b-1636" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2223-b0fe-f380-0b0d" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2161-15bd-f8a3-750b" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ef-18ac-e4b0-39cf" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2223-b0fe-f380-0b0d" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2161-15bd-f8a3-750b" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ef-18ac-e4b0-39cf" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b13b-5f1c-1c0b-1636" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b13b-5f1c-1c0b-1636" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="0641-b07e-e070-0f65" name="Transports" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="false">
           <modifiers>
-            <modifier type="increment" field="6755-d67f-b2c7-bed3" value="1.0">
+            <modifier type="increment" field="6755-d67f-b2c7-bed3" value="1">
               <repeats>
-                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6755-d67f-b2c7-bed3" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6755-d67f-b2c7-bed3" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="1958-347c-b151-4ea6" name="Tows" hidden="false" targetId="f3c7-5675-463e-b566" primary="false">
           <modifiers>
-            <modifier type="increment" field="bf73-1da1-2ee6-3fdc" value="1.0">
+            <modifier type="increment" field="bf73-1da1-2ee6-3fdc" value="1">
               <repeats>
-                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5056-7005-6edc-4816" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5056-7005-6edc-4816" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf73-1da1-2ee6-3fdc" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf73-1da1-2ee6-3fdc" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="dba3-bd1f-1451-cd7e" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false">
           <modifiers>
-            <modifier type="increment" field="6639-9f27-e106-a7a4" value="1.0">
+            <modifier type="increment" field="6639-9f27-e106-a7a4" value="1">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00b4-e9d7-e705-1f53" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00b4-e9d7-e705-1f53" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6639-9f27-e106-a7a4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6639-9f27-e106-a7a4" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="1541-25f2-c173-62a0" name="Infantry Support Squads" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="false"/>
@@ -402,48 +402,48 @@
         <categoryLink id="e254-1c36-3d8b-cf38" name="Walkers" hidden="false" targetId="2161-15bd-f8a3-750b" primary="false"/>
         <categoryLink id="f777-7f7d-f4c7-60b7" name="Marine, Paragon, Paragon Support squads only" hidden="false" targetId="2fa0-e678-ad52-d310" primary="false">
           <modifiers>
-            <modifier type="increment" field="e9aa-3681-ea4e-4c9e" value="1.0">
+            <modifier type="increment" field="e9aa-3681-ea4e-4c9e" value="1">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9aa-3681-ea4e-4c9e" type="min"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9aa-3681-ea4e-4c9e" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d980-644d-2aa3-d9c9" name="Forward Air Observer" hidden="false" targetId="1a15-5468-fc36-e232" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="633a-c0f8-f7f8-ac45" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="633a-c0f8-f7f8-ac45" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d04f-604d-ae10-5091" name="Forward Artillery Observer" hidden="false" targetId="1f3d-c608-4cb7-2ec0" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3ee-230b-27c8-f497" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3ee-230b-27c8-f497" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="1100-a99e-7ba0-3a61" name="Light and Medium Mortar Team" hidden="false" targetId="9e4b-337b-7b0a-20f2" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cbd-ecdc-8614-ec56" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cbd-ecdc-8614-ec56" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="b2d7-4ec4-b71f-88aa" name="Light Artillery, Light &amp; Medium AT Guns, Medium &amp; Heavy Artillery" hidden="false" targetId="ee23-0c13-8958-df3f" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c66e-e02e-93c3-1eb1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c66e-e02e-93c3-1eb1" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="e5d1-d6fa-1a31-532a" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="false"/>
         <categoryLink id="e370-1397-014c-1c92" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="false"/>
-        <categoryLink id="c085-2b0e-e9b4-493a" name="Armored Officer" hidden="false" targetId="31fe-b631-5c13-5493" primary="false">
+        <categoryLink id="c085-2b0e-e9b4-493a" name="US Armored Officer" hidden="false" targetId="31fe-b631-5c13-5493" primary="false">
           <modifiers>
-            <modifier type="set" field="24ad-91fb-edf9-c289" value="1.0">
+            <modifier type="set" field="24ad-91fb-edf9-c289" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9cf3-0bc0-7974-b411" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9cf3-0bc0-7974-b411" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24ad-91fb-edf9-c289" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24ad-91fb-edf9-c289" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="bcbf-498e-8604-082b" name="Armoured Cars and Anti-Aircraft Vehicles" hidden="false" targetId="5c3c-21b9-e716-a67e" primary="false"/>
@@ -458,115 +458,115 @@
       <categoryLinks>
         <categoryLink id="5069-ac74-9dc8-0eea" name="Commander" hidden="false" targetId="fb1a-cb93-a427-51cf" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f256-2fc0-05de-f006" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd53-9475-6506-b001" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f256-2fc0-05de-f006" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd53-9475-6506-b001" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="b67a-2805-042a-e97e" name="Infantry Squads" hidden="false" targetId="360a-867e-e501-63b2" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a3b-a326-cdc7-1623" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d2c-5752-9c69-be48" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a3b-a326-cdc7-1623" type="min"/>
+            <constraint field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d2c-5752-9c69-be48" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="0c58-3d65-2973-4ba4" name="Senior Officer" hidden="false" targetId="b14d-60bd-51cb-1c49" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d588-5d82-ed3b-feed" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d588-5d82-ed3b-feed" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="f8d3-99bc-87ec-2df0" name="Medic" hidden="false" targetId="64b3-a04b-d6d0-add2" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10ed-c757-a629-b74d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10ed-c757-a629-b74d" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="eab2-0c8c-ea88-4b93" name="Forward Observer" hidden="false" targetId="c048-dfb7-583d-2e79" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f58-b60e-8050-e650" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f58-b60e-8050-e650" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="f325-a777-4ac7-464f" name="Machine Gun Team" hidden="false" targetId="1688-881c-5284-0be8" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4f9-5f2c-7889-e773" type="max"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4f9-5f2c-7889-e773" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="4dff-68cc-d2dc-8c19" name="Mortar Team" hidden="false" targetId="d9b6-6214-f7d0-e6f4" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbe1-63f0-c73a-b4a4" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbe1-63f0-c73a-b4a4" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="1839-4707-a431-fb22" name="Sniper Team" hidden="false" targetId="6077-3929-61c8-5eb7" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ccf-c315-341a-7c2a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ccf-c315-341a-7c2a" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d2bf-1baf-0e81-ae3b" name="Flamethrower Team" hidden="false" targetId="c5aa-dfef-70b7-726b" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa71-12c7-0ea6-038c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa71-12c7-0ea6-038c" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="cfea-d00f-2836-c034" name="Anti-Tank Team" hidden="false" targetId="c04e-ff05-f7cb-ae9b" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2b1-c3ff-c611-b5be" type="max"/>
+            <constraint field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2b1-c3ff-c611-b5be" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="466f-35a9-4f1c-4e0e" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59d5-6ba6-d5e6-0801" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59d5-6ba6-d5e6-0801" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="a89b-a35e-36a1-6118" name="Armored Cars, Scout and Light Walkers" hidden="false" targetId="00b4-e9d7-e705-1f53" primary="false">
           <modifiers>
-            <modifier type="increment" field="cb8c-7131-7ea8-1634" value="1.0">
+            <modifier type="increment" field="cb8c-7131-7ea8-1634" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2223-b0fe-f380-0b0d" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2161-15bd-f8a3-750b" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ef-18ac-e4b0-39cf" type="greaterThan"/>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2223-b0fe-f380-0b0d" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2161-15bd-f8a3-750b" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ef-18ac-e4b0-39cf" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45ac-0cd1-0fd0-edd3" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb8c-7131-7ea8-1634" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb8c-7131-7ea8-1634" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="0b24-c791-cf27-b359" name="Transports" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="false">
           <modifiers>
-            <modifier type="increment" field="9e3b-0d9c-8c26-f496" value="1.0">
+            <modifier type="increment" field="9e3b-0d9c-8c26-f496" value="1">
               <repeats>
-                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e3b-0d9c-8c26-f496" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e3b-0d9c-8c26-f496" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="daf7-1ee6-802e-71d7" name="Tows" hidden="false" targetId="f3c7-5675-463e-b566" primary="false">
           <modifiers>
-            <modifier type="increment" field="0d18-38ee-3d5d-3a2e" value="1.0">
+            <modifier type="increment" field="0d18-38ee-3d5d-3a2e" value="1">
               <repeats>
-                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5056-7005-6edc-4816" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6524-8844-780f-c4cc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5056-7005-6edc-4816" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d18-38ee-3d5d-3a2e" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d18-38ee-3d5d-3a2e" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="ddaf-2649-e553-3996" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false">
           <modifiers>
-            <modifier type="increment" field="8de2-ffb2-3c00-b44f" value="1.0">
+            <modifier type="increment" field="8de2-ffb2-3c00-b44f" value="1">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00b4-e9d7-e705-1f53" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00b4-e9d7-e705-1f53" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8de2-ffb2-3c00-b44f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8de2-ffb2-3c00-b44f" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="7cb9-ae5d-7c65-8d77" name="Infantry Support Squads" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="false"/>
@@ -574,36 +574,36 @@
         <categoryLink id="a741-ad9a-7915-ec3b" name="Walkers" hidden="false" targetId="2161-15bd-f8a3-750b" primary="false"/>
         <categoryLink id="2d82-e165-8672-4b0d" name="Heavy Infantry, Paragon, and Paragon Support squads" hidden="false" targetId="9cf3-0bc0-7974-b411" primary="false">
           <modifiers>
-            <modifier type="increment" field="2b70-8d95-410b-7f55" value="1.0">
+            <modifier type="increment" field="2b70-8d95-410b-7f55" value="1">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="360a-867e-e501-63b2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
-            <modifier type="increment" field="2b70-8d95-410b-7f55" value="1.0">
+            <modifier type="increment" field="2b70-8d95-410b-7f55" value="1">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c04e-ff05-f7cb-ae9b" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c04e-ff05-f7cb-ae9b" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
-            <modifier type="increment" field="2b70-8d95-410b-7f55" value="1.0">
+            <modifier type="increment" field="2b70-8d95-410b-7f55" value="1">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fb1a-cb93-a427-51cf" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fb1a-cb93-a427-51cf" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b70-8d95-410b-7f55" type="min"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b70-8d95-410b-7f55" type="min"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="caa2-c458-95df-502d" name="Armored Officer" hidden="false" targetId="31fe-b631-5c13-5493" primary="false">
+        <categoryLink id="caa2-c458-95df-502d" name="US Armored Officer" hidden="false" targetId="31fe-b631-5c13-5493" primary="false">
           <modifiers>
-            <modifier type="set" field="7a1f-4d54-bbab-f6dc" value="1.0">
+            <modifier type="set" field="7a1f-4d54-bbab-f6dc" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9cf3-0bc0-7974-b411" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9cf3-0bc0-7974-b411" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a1f-4d54-bbab-f6dc" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a1f-4d54-bbab-f6dc" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="e135-bc2a-5239-f11d" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="false"/>
@@ -623,23 +623,23 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="b384-1a54-a165-5286" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="8930-58f3-822f-44bd">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fb6-6a0d-940e-f439" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abd0-604d-f60f-3f1a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fb6-6a0d-940e-f439" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abd0-604d-f60f-3f1a" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="8930-58f3-822f-44bd" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="35.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="35"/>
               </costs>
             </entryLink>
             <entryLink id="1218-9e6e-e271-5321" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="65.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="65"/>
               </costs>
             </entryLink>
             <entryLink id="2a87-7fe3-72b0-a8e4" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="50.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="50"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -648,13 +648,13 @@
       <entryLinks>
         <entryLink id="9f14-38ae-062e-5fc9" name="MMG" hidden="false" collective="false" import="true" targetId="ff34-acf0-0405-2cfb" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94bf-4706-a9f5-bf19" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f25a-d7b3-80ab-465a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94bf-4706-a9f5-bf19" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f25a-d7b3-80ab-465a" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b533-d1ee-dc8e-8afb" name=".50 Cal Heavy Machine Gun Team" page="150" hidden="false" collective="false" import="true" type="unit">
@@ -664,28 +664,28 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="fcc5-d991-c933-d69a" name="Machine Gun Team" hidden="false" targetId="1688-881c-5284-0be8" primary="false"/>
-        <categoryLink id="de76-1a48-a680-8960" name="New CategoryLink" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
+        <categoryLink id="de76-1a48-a680-8960" name="Infantry Support Squads" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="7162-53f7-05d7-3ce8" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="520a-482a-0fb3-3649">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa5c-8f43-83a6-f824" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5822-6356-9e23-7453" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa5c-8f43-83a6-f824" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5822-6356-9e23-7453" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="520a-482a-0fb3-3649" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="49.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="49"/>
               </costs>
             </entryLink>
             <entryLink id="c23d-ec07-a1b5-b68a" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="91.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="91"/>
               </costs>
             </entryLink>
             <entryLink id="0400-9df6-3394-3c77" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="70.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="70"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -694,13 +694,13 @@
       <entryLinks>
         <entryLink id="d822-1df5-a0c4-e507" name="HMG" hidden="false" collective="false" import="true" targetId="26df-ebe9-f37a-4485" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6943-1daa-5a5d-58d7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63a9-f7d2-c065-1c3b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6943-1daa-5a5d-58d7" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63a9-f7d2-c065-1c3b" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6edd-3518-bea0-dd64" name="105mm M2A1 Medium Howitzer" hidden="false" collective="false" import="true" type="unit">
@@ -709,7 +709,7 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -719,51 +719,51 @@
         <infoLink id="54c8-1851-48b1-cd1f" name="4" hidden="false" targetId="f05e-dc7f-d24f-7acb" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="50eb-03e6-b593-523a" name="New CategoryLink" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
+        <categoryLink id="50eb-03e6-b593-523a" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
         <categoryLink id="2d34-06c4-8ab6-0351" name="Heavy and Super Heavy AT Guns, Medium and Heavy Artillery" hidden="false" targetId="2b0f-97b2-f74a-0007" primary="false"/>
         <categoryLink id="2cdd-50e0-2b26-c5aa" name="Light Artillery, Light &amp; Medium AT Guns, Medium &amp; Heavy Artillery" hidden="false" targetId="ee23-0c13-8958-df3f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e801-b0ba-c58d-8045" name="Gun Shield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f13-f9cd-ee55-07f7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f13-f9cd-ee55-07f7" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="36cb-268e-81fe-dc81" name="Gun Shield" hidden="false" targetId="12a2-4a18-eb50-2652" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e290-50e9-3fe6-fc38" name="Spotter" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="547e-222b-9bff-fc09" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="547e-222b-9bff-fc09" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="059e-1ec5-0642-3403" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="2059-6569-d372-7189">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d63d-9f9d-9e1b-bf3a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f9d-c486-4b70-bc95" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d63d-9f9d-9e1b-bf3a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f9d-c486-4b70-bc95" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="2059-6569-d372-7189" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="56.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="56"/>
               </costs>
             </entryLink>
             <entryLink id="67dc-c3b5-6f05-bc1c" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="84.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="84"/>
               </costs>
             </entryLink>
             <entryLink id="f8d1-1d3b-b74c-3252" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="70.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="70"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -772,13 +772,13 @@
       <entryLinks>
         <entryLink id="88a0-2356-f29b-b8df" name="Medium Howitzer" hidden="false" collective="false" import="true" targetId="b249-641b-1c00-2f92" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a72a-df3a-b819-b049" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08b7-a014-5f48-aa50" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a72a-df3a-b819-b049" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08b7-a014-5f48-aa50" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="35f1-b3e5-5309-9ee4" name="107mm Heavy Mortar" hidden="false" collective="false" import="true" type="unit">
@@ -787,8 +787,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -798,40 +798,40 @@
         <infoLink id="b1b4-4eab-a4e6-f8ac" name="4" hidden="false" targetId="f05e-dc7f-d24f-7acb" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="c882-ffa8-f52a-fed6" name="New CategoryLink" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
+        <categoryLink id="c882-ffa8-f52a-fed6" name="Infantry Support Squads" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
         <categoryLink id="df0e-2b15-6580-657c" name="Mortar Team" hidden="false" targetId="d9b6-6214-f7d0-e6f4" primary="false"/>
         <categoryLink id="ad14-2f9a-5e15-39c3" name="Heavy Mortar Team" hidden="false" targetId="4195-7b78-7f05-2c68" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9efd-08e0-11f5-d78e" name="Spotter" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d07f-b9ed-eb58-fe08" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d07f-b9ed-eb58-fe08" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="ca69-72ef-249b-b394" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="fc17-56fc-2407-d6ff">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7470-62b2-2555-db97" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75c5-fa82-0e07-7ae9" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7470-62b2-2555-db97" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75c5-fa82-0e07-7ae9" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="fc17-56fc-2407-d6ff" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="46.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="46"/>
               </costs>
             </entryLink>
             <entryLink id="271b-0993-a097-3fe7" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="84.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="84"/>
               </costs>
             </entryLink>
             <entryLink id="effc-4b4f-875c-ecdd" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="65.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="65"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -840,13 +840,13 @@
       <entryLinks>
         <entryLink id="5a85-1c74-21dd-98bb" name="Heavy Mortar" hidden="false" collective="false" import="true" targetId="489b-4134-1a49-c442" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb5d-e627-7073-51e4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e392-3139-2568-340c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb5d-e627-7073-51e4" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e392-3139-2568-340c" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6f1d-87a5-7aec-002d" name="155mm Heavy Howitzer" hidden="false" collective="false" import="true" type="unit">
@@ -855,8 +855,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -866,40 +866,40 @@
         <infoLink id="39b4-2b3b-aafb-6b01" name="5" hidden="false" targetId="efe1-2d4f-9fad-6602" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3736-07be-7fc8-8ec3" name="New CategoryLink" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
+        <categoryLink id="3736-07be-7fc8-8ec3" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
         <categoryLink id="47d9-a1e5-3ce6-bc2f" name="Heavy and Super Heavy AT Guns, Medium and Heavy Artillery" hidden="false" targetId="2b0f-97b2-f74a-0007" primary="false"/>
         <categoryLink id="6cdb-9381-1b66-4455" name="Light Artillery, Light &amp; Medium AT Guns, Medium &amp; Heavy Artillery" hidden="false" targetId="ee23-0c13-8958-df3f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="13c7-08c4-afb7-9d57" name="Spotter" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="296c-81dd-502c-688d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="296c-81dd-502c-688d" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="76f5-653e-a65d-b6a5" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="e096-f129-ff2a-39ac">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d028-0008-b98a-2ca8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29eb-55f8-012e-3918" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d028-0008-b98a-2ca8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29eb-55f8-012e-3918" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="e096-f129-ff2a-39ac" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="88.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="88"/>
               </costs>
             </entryLink>
             <entryLink id="18e5-9f3b-2f8b-1a05" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="132.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="132"/>
               </costs>
             </entryLink>
             <entryLink id="20bd-d5f3-b6be-be40" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="110.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="110"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -908,13 +908,13 @@
       <entryLinks>
         <entryLink id="5f26-249b-e94d-80a4" name="Heavy Howitzer" hidden="false" collective="false" import="true" targetId="5007-330d-54cc-bf7c" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3785-d18d-4871-a370" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a606-0faf-dcac-f65c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3785-d18d-4871-a370" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a606-0faf-dcac-f65c" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d213-a02e-ca30-c824" name="3-Inch Anti-Tank Gun" hidden="false" collective="false" import="true" type="unit">
@@ -923,8 +923,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -935,29 +935,29 @@
         <infoLink id="fde3-11a8-10f2-526d" name="Gun Shield" hidden="false" targetId="12a2-4a18-eb50-2652" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8884-c8f2-b20a-d267" name="New CategoryLink" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
+        <categoryLink id="8884-c8f2-b20a-d267" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
         <categoryLink id="e403-5c0f-ccb0-bf83" name="Heavy and Super Heavy AT Guns, Medium and Heavy Artillery" hidden="false" targetId="2b0f-97b2-f74a-0007" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2fe7-7323-4dd0-1344" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="d6bf-c686-2984-da66">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6046-8b4c-265f-89b8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e94-8b4e-c87f-6820" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6046-8b4c-265f-89b8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e94-8b4e-c87f-6820" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="d6bf-c686-2984-da66" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="88.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="88"/>
               </costs>
             </entryLink>
             <entryLink id="c118-9e15-e4ed-d0ef" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="132.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="132"/>
               </costs>
             </entryLink>
             <entryLink id="3f12-99ac-6b53-f6e2" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="110.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="110"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -966,13 +966,13 @@
       <entryLinks>
         <entryLink id="f876-6837-b6cb-5668" name="Heavy AT Gun" hidden="false" collective="false" import="true" targetId="6097-5029-9ccd-f779" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ce9-6420-f9a6-6576" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c12-1011-ca64-efa4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ce9-6420-f9a6-6576" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c12-1011-ca64-efa4" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a5bb-52f4-fc2b-281e" name="37mm Anti-Tank Gun" hidden="false" collective="false" import="true" type="unit">
@@ -981,30 +981,30 @@
         <infoLink id="5d20-d09e-4ef4-3d56" name="Gun Shield" hidden="false" targetId="12a2-4a18-eb50-2652" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ea59-fb7e-1436-ead9" name="New CategoryLink" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
+        <categoryLink id="ea59-fb7e-1436-ead9" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
         <categoryLink id="cdad-a645-5d70-bb56" name="Light Artillery, Light &amp; Medium AT Guns, Medium &amp; Heavy Artillery" hidden="false" targetId="ee23-0c13-8958-df3f" primary="false"/>
         <categoryLink id="2b39-f23f-34bc-5c86" name="Light Artillery, Light and Medium AT Guns" hidden="false" targetId="1842-7654-2d60-c182" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="6dd8-df2b-3396-0cfb" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="ca03-2ea2-fbdc-1ab2">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7477-0c93-6584-c131" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11f1-7b95-ac91-7f02" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7477-0c93-6584-c131" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11f1-7b95-ac91-7f02" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="ca03-2ea2-fbdc-1ab2" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="40.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="40"/>
               </costs>
             </entryLink>
             <entryLink id="c7ae-33e4-7389-1df3" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="60.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="60"/>
               </costs>
             </entryLink>
             <entryLink id="d611-2553-5156-e9fe" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="50.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="50"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1013,13 +1013,13 @@
       <entryLinks>
         <entryLink id="5312-0fcf-08e4-8f1a" name="Light AT Gun" hidden="false" collective="false" import="true" targetId="169b-30ba-4907-7e96" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3034-0ad4-7e8e-6cdf" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6461-35fb-b5f4-7338" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3034-0ad4-7e8e-6cdf" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6461-35fb-b5f4-7338" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f5d2-60af-34bc-8e6f" name="57mm Anti-Tank Gun" hidden="false" collective="false" import="true" type="unit">
@@ -1028,30 +1028,30 @@
         <infoLink id="fdd8-7523-e42f-f9ef" name="Gun Shield" hidden="false" targetId="12a2-4a18-eb50-2652" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7c46-9a78-3deb-03b7" name="New CategoryLink" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
+        <categoryLink id="7c46-9a78-3deb-03b7" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
         <categoryLink id="868a-f477-c35a-6831" name="Light Artillery, Light &amp; Medium AT Guns, Medium &amp; Heavy Artillery" hidden="false" targetId="ee23-0c13-8958-df3f" primary="false"/>
         <categoryLink id="8fc0-6459-15f2-20b7" name="Light Artillery, Light and Medium AT Guns" hidden="false" targetId="1842-7654-2d60-c182" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="6d95-4e57-654d-0bf2" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="a0c0-2456-281f-f629">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ef1-889b-fd73-6684" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cafc-465f-c8c1-8454" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ef1-889b-fd73-6684" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cafc-465f-c8c1-8454" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="a0c0-2456-281f-f629" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="60.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="60"/>
               </costs>
             </entryLink>
             <entryLink id="12f4-69c2-098d-7eae" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="90.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="90"/>
               </costs>
             </entryLink>
             <entryLink id="822f-3463-5c3e-fbfd" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="75.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="75"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1060,13 +1060,13 @@
       <entryLinks>
         <entryLink id="3da5-ce0b-a91d-e508" name="Medium AT Gun" hidden="false" collective="false" import="true" targetId="18d0-3b64-50f8-83e6" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08ce-8710-59ff-3761" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4000-88eb-bfdd-6b2a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08ce-8710-59ff-3761" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4000-88eb-bfdd-6b2a" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b4ae-cd36-be4a-4cb1" name="57mm M18" hidden="false" collective="false" import="true" type="unit">
@@ -1075,23 +1075,23 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7f87-2e81-04e8-08db" name="Light Artillery, Light and Medium AT Guns" hidden="false" targetId="1842-7654-2d60-c182" primary="false"/>
-        <categoryLink id="3d79-c312-a9e1-55d4" name="New CategoryLink" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
+        <categoryLink id="3d79-c312-a9e1-55d4" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1033-62b5-4750-dd06" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="befa-62cf-c3b2-f628">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d40b-8847-ee49-f378" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9746-0892-381d-45b6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d40b-8847-ee49-f378" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9746-0892-381d-45b6" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="73f6-4776-f283-87db" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="36.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="36"/>
               </costs>
             </entryLink>
             <entryLink id="befa-62cf-c3b2-f628" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="30.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="30"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1100,13 +1100,13 @@
       <entryLinks>
         <entryLink id="a641-95b0-4295-5f04" name="Light Howitzer (D3 HE)" hidden="false" collective="false" import="true" targetId="e3c3-7005-fe07-fa3d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="730d-28a6-02d2-2557" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4de0-0275-1574-bda8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="730d-28a6-02d2-2557" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4de0-0275-1574-bda8" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c827-cbd6-a78e-9d12" name="60mm Light Mortar" hidden="false" collective="false" import="true" type="unit">
@@ -1114,30 +1114,30 @@
         <infoLink id="ab62-bc05-be83-bafd" name="2" hidden="false" targetId="b6c1-c83f-a555-17ce" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ab7f-7f90-32a6-1d70" name="New CategoryLink" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
+        <categoryLink id="ab7f-7f90-32a6-1d70" name="Infantry Support Squads" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
         <categoryLink id="2f4f-8998-50b3-f56a" name="Light and Medium Mortar Team" hidden="false" targetId="9e4b-337b-7b0a-20f2" primary="false"/>
         <categoryLink id="4ccd-b040-3665-9046" name="Mortar Team" hidden="false" targetId="d9b6-6214-f7d0-e6f4" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1a87-72bb-e7a2-e4ae" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="6348-2931-7774-1d73">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cff7-2cbc-0985-ac8e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6941-c3ac-091a-ae99" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cff7-2cbc-0985-ac8e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6941-c3ac-091a-ae99" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="6348-2931-7774-1d73" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="24.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="24"/>
               </costs>
             </entryLink>
             <entryLink id="79e7-c6cd-3c3c-062c" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="46.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="46"/>
               </costs>
             </entryLink>
             <entryLink id="6e9f-3b2a-9e76-27dc" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="35.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="35"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1146,13 +1146,13 @@
       <entryLinks>
         <entryLink id="5197-c83b-d812-32a0" name="Light Mortar" hidden="false" collective="false" import="true" targetId="a995-196d-d370-750c" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db1a-1c09-95d7-12ea" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf43-e961-d0a4-2b82" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db1a-1c09-95d7-12ea" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf43-e961-d0a4-2b82" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="06ce-4307-cd23-b0bf" name="75mm Light Howitzer" hidden="false" collective="false" import="true" type="unit">
@@ -1160,43 +1160,43 @@
         <infoLink id="f62b-62ef-feac-56ba" name="3" hidden="false" targetId="7368-80e0-15af-d330" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="cb22-98c9-e72b-f06b" name="New CategoryLink" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
+        <categoryLink id="cb22-98c9-e72b-f06b" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
         <categoryLink id="51e5-c0d3-2a42-196c" name="Light Artillery, Light and Medium AT Guns" hidden="false" targetId="1842-7654-2d60-c182" primary="false"/>
         <categoryLink id="673d-19e0-4872-7679" name="Light Artillery, Light &amp; Medium AT Guns, Medium &amp; Heavy Artillery" hidden="false" targetId="ee23-0c13-8958-df3f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="198a-2ace-e807-1396" name="Gun Shield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d6a-4a63-5941-3223" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d6a-4a63-5941-3223" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="aeac-3378-8ecc-1d7e" name="Gun Shield" hidden="false" targetId="12a2-4a18-eb50-2652" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="cff3-10d0-fec7-09a4" name="Quality" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="290a-d332-e6f8-3fca" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fce2-3dba-86d7-0b53" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="290a-d332-e6f8-3fca" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fce2-3dba-86d7-0b53" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="0e74-8773-431d-917c" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="36.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="36"/>
               </costs>
             </entryLink>
             <entryLink id="6e0d-e0b8-c9d7-d4af" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="54.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="54"/>
               </costs>
             </entryLink>
             <entryLink id="a122-d86c-28de-83fb" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="45.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="45"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1205,13 +1205,13 @@
       <entryLinks>
         <entryLink id="5568-1b1c-87b3-40cf" name="Light Howitzer" hidden="false" collective="false" import="true" targetId="e6cc-3474-2994-85a9" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e51f-a67a-8338-a8e9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0e6-3f64-e08d-6300" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e51f-a67a-8338-a8e9" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0e6-3f64-e08d-6300" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ec3-1d40-e514-e474" name="75mm M20" hidden="false" collective="false" import="true" type="unit">
@@ -1219,24 +1219,24 @@
         <infoLink id="5585-7227-a615-a26f" name="3" hidden="false" targetId="7368-80e0-15af-d330" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="19ab-d3d1-ae51-e398" name="New CategoryLink" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
+        <categoryLink id="19ab-d3d1-ae51-e398" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
         <categoryLink id="95b5-7668-a16a-4563" name="Light Artillery, Light and Medium AT Guns" hidden="false" targetId="1842-7654-2d60-c182" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="8076-6f52-396d-0d9a" name="Quality" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd4b-f965-ec59-0636" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f97-dbd9-3981-31a4" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd4b-f965-ec59-0636" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f97-dbd9-3981-31a4" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="7ceb-fb5e-b9a7-86a0" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="54.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="54"/>
               </costs>
             </entryLink>
             <entryLink id="d6ff-3c80-5094-d1ad" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="45.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="45"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1245,13 +1245,13 @@
       <entryLinks>
         <entryLink id="4f80-b527-bb19-b987" name="Light Howitzer" hidden="false" collective="false" import="true" targetId="e6cc-3474-2994-85a9" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe45-5ee1-59e0-aef1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acfb-2474-93e3-b8c1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe45-5ee1-59e0-aef1" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acfb-2474-93e3-b8c1" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ae81-3bb0-6b24-04f5" name="81mm Medium Mortar" hidden="false" collective="false" import="true" type="unit">
@@ -1259,40 +1259,40 @@
         <infoLink id="601f-ed7f-5d5b-d205" name="3" hidden="false" targetId="7368-80e0-15af-d330" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8024-255a-2465-b041" name="New CategoryLink" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
+        <categoryLink id="8024-255a-2465-b041" name="Infantry Support Squads" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
         <categoryLink id="e954-8d94-59d7-a7f2" name="Light and Medium Mortar Team" hidden="false" targetId="9e4b-337b-7b0a-20f2" primary="false"/>
         <categoryLink id="143b-a577-b138-af4d" name="Mortar Team" hidden="false" targetId="d9b6-6214-f7d0-e6f4" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8e3f-1150-a769-ce6d" name="Spotter" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfd2-87a8-1ba9-5f97" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfd2-87a8-1ba9-5f97" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="1f27-ef2a-2971-dbdd" name="Quality" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c742-e7db-3d51-950c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5193-7e21-e1b5-92be" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c742-e7db-3d51-950c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5193-7e21-e1b5-92be" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="c244-4ee4-ed8f-5a83" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="35.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="35"/>
               </costs>
             </entryLink>
             <entryLink id="7078-c314-b0db-bfde" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="65.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="65"/>
               </costs>
             </entryLink>
             <entryLink id="7531-140a-a296-3d9e" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="50.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="50"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1301,53 +1301,53 @@
       <entryLinks>
         <entryLink id="172d-96d2-8c72-d088" name="Medium Mortar" hidden="false" collective="false" import="true" targetId="565d-33ad-6e9f-e303" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9062-5155-9de9-a073" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f907-5e95-8c4a-77dc" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9062-5155-9de9-a073" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f907-5e95-8c4a-77dc" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4df5-96c2-0f63-6bcd" name="Bazooka Team" page="150" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="ae37-8809-fabb-7d90" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+            <condition field="selections" scope="ae37-8809-fabb-7d90" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ccb9-514e-d288-da5d" type="max"/>
+        <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ccb9-514e-d288-da5d" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="3c15-342d-4559-23b1" name="2" hidden="false" targetId="b6c1-c83f-a555-17ce" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1d6e-33c1-ad14-662a" name="New CategoryLink" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
+        <categoryLink id="1d6e-33c1-ad14-662a" name="Infantry Support Squads" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
         <categoryLink id="7ee7-e3d2-7c75-90bb" name="Anti-Tank Team" hidden="false" targetId="c04e-ff05-f7cb-ae9b" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9f1f-ba64-97b9-0d4e" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="959a-b220-7113-c023">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b72b-6cd5-c3bf-3f2a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="876e-9108-62e7-0c18" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b72b-6cd5-c3bf-3f2a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="876e-9108-62e7-0c18" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="959a-b220-7113-c023" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="42.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="42"/>
               </costs>
             </entryLink>
             <entryLink id="7ee7-657b-8f3b-4c97" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="60.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="60"/>
               </costs>
             </entryLink>
             <entryLink id="5f60-6753-700e-ed47" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="78.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="78"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1356,13 +1356,13 @@
       <entryLinks>
         <entryLink id="a7c5-4008-342d-e615" name="Bazooka" hidden="false" collective="false" import="true" targetId="1f59-fcb3-b035-5e82" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="522c-f9e9-5c78-f299" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b0-3d81-3e14-c934" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="522c-f9e9-5c78-f299" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b0-3d81-3e14-c934" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c3f1-a8df-8964-b8f1" name="Flamethrower Team" page="150" hidden="false" collective="false" import="true" type="unit">
@@ -1371,23 +1371,23 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f8f0-36de-4e12-b5ac" name="Flamethrower Team" hidden="false" targetId="c5aa-dfef-70b7-726b" primary="false"/>
-        <categoryLink id="2e50-7206-8750-4d76" name="New CategoryLink" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
+        <categoryLink id="2e50-7206-8750-4d76" name="Infantry Support Squads" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="da00-baeb-d966-fe52" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="52ed-7417-da81-83f5">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="842c-43ed-323f-62fa" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b0c-9f26-8804-a61c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="842c-43ed-323f-62fa" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b0c-9f26-8804-a61c" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="52ed-7417-da81-83f5" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="50.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="50"/>
               </costs>
             </entryLink>
             <entryLink id="f78d-b2f9-7648-60ff" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="65.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="65"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1396,13 +1396,13 @@
       <entryLinks>
         <entryLink id="40c4-7b20-5c39-77f3" name="Flamethrower (Infantry)" hidden="false" collective="false" import="true" targetId="d5e9-fd6f-525c-f542" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b061-21d3-51cf-0bba" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="616d-8fa6-ac02-68a8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b061-21d3-51cf-0bba" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="616d-8fa6-ac02-68a8" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1fa7-eca5-8501-4463" name="Heavy Bazooka Team" page="150" hidden="false" collective="false" import="true" type="unit">
@@ -1411,8 +1411,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -1426,47 +1426,47 @@
         <infoLink id="472a-57b1-c049-82fc" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5fe0-9243-9d9a-4cab" name="New CategoryLink" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
+        <categoryLink id="5fe0-9243-9d9a-4cab" name="Infantry Support Squads" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
         <categoryLink id="4e76-bbb4-70cc-3bfc" name="Anti-Tank Team" hidden="false" targetId="c04e-ff05-f7cb-ae9b" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9b95-f660-d630-a51a" name="Loader" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a23-15a5-5d34-d745" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cb9-5dd5-f4cf-f325" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a23-15a5-5d34-d745" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cb9-5dd5-f4cf-f325" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="4ea2-7b31-cd30-9443" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="2028-537e-fe2b-8dba" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b4a-7fd2-9933-faba" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d72-03cc-98ea-cc25" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b4a-7fd2-9933-faba" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d72-03cc-98ea-cc25" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9105-7fc0-cdd1-eed1" name="NCO" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a26-0772-a33a-3f70" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf15-c614-84e9-6e37" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a26-0772-a33a-3f70" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf15-c614-84e9-6e37" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="2f2b-0b63-18f1-457a" name="Super-Bazooka" hidden="false" collective="false" import="true" targetId="44e3-67cb-3abc-f13c" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7924-8030-43f8-cc78" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bb6-fa53-35dc-67eb" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7924-8030-43f8-cc78" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bb6-fa53-35dc-67eb" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="128.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="128"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c001-5fc1-cc5c-0bff" name="Heavy Infantry Squad" page="148" hidden="false" collective="false" import="true" type="unit">
@@ -1475,8 +1475,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -1488,40 +1488,40 @@
         <infoLink id="2f47-3a4c-ee28-2447" name="Resilient" hidden="false" targetId="f45a-914c-bccf-5a1c" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0968-2ab9-cf24-ac0c" name="New CategoryLink" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
+        <categoryLink id="0968-2ab9-cf24-ac0c" name="Infantry Squads" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
         <categoryLink id="a991-7ee1-65de-0d01" name="Heavy Infantry, Paragon, and Paragon Support squads" hidden="false" targetId="9cf3-0bc0-7974-b411" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="f4da-6795-0481-a3ba" name="Anti-Tank Grenades" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="2.0">
+            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="2">
               <repeats>
-                <repeat field="selections" scope="c001-5fc1-cc5c-0bff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="c001-5fc1-cc5c-0bff" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ee8-7156-5ffa-aed6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ee8-7156-5ffa-aed6" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="7490-6aa7-d141-491a" name="Tank Hunters" hidden="false" targetId="c707-cf7b-113b-507b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="286d-0b96-0a7e-8ee7" name="Squad Members" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c020-2571-4b10-9591" type="min"/>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0aea-1280-e1af-4f3a" type="max"/>
+            <constraint field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c020-2571-4b10-9591" type="min"/>
+            <constraint field="selections" scope="parent" value="10" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0aea-1280-e1af-4f3a" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="1799-2975-8dd5-535f" name="NCO" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ec0-eb5b-f414-4455" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="636c-3c32-b047-07cc" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ec0-eb5b-f414-4455" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="636c-3c32-b047-07cc" type="min"/>
               </constraints>
               <infoLinks>
                 <infoLink id="ef6f-f3c7-d2aa-b66a" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -1529,8 +1529,8 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="7ee9-14a3-add0-cfa5" name="Weapon" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f17a-bdb2-ee34-1b09" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="873f-c23e-845a-eefc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f17a-bdb2-ee34-1b09" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="873f-c23e-845a-eefc" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="422d-7293-9dcc-0c26" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="7cdc-1638-6e4c-f0fa" type="selectionEntry"/>
@@ -1538,13 +1538,13 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="21.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="21"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="43aa-43d6-32ee-75ed" name="Heavy Infantry" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62c9-dab7-bc3e-229f" type="min"/>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb2a-fdf7-d4c3-a6e6" type="max"/>
+                <constraint field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62c9-dab7-bc3e-229f" type="min"/>
+                <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb2a-fdf7-d4c3-a6e6" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="22b8-a26c-a50c-4a7e" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -1552,20 +1552,20 @@
               <entryLinks>
                 <entryLink id="1494-8513-620c-74bb" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="7cdc-1638-6e4c-f0fa" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8d8-1158-f793-416b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b436-a664-1fd0-13ad" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8d8-1158-f793-416b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b436-a664-1fd0-13ad" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="21.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="21"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2ce0-4c13-f637-93b3" name="Infantry Squad" page="148" hidden="false" collective="false" import="true" type="unit">
@@ -1574,33 +1574,33 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="249a-b6d0-47bd-85c6" name="New CategoryLink" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
+        <categoryLink id="249a-b6d0-47bd-85c6" name="Infantry Squads" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="355e-2215-512a-f458" name="Anti-Tank Grenades" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="2.0">
+            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="2">
               <repeats>
-                <repeat field="selections" scope="2ce0-4c13-f637-93b3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="2ce0-4c13-f637-93b3" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2996-2c2f-c370-8b49" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2996-2c2f-c370-8b49" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="4966-f462-c0db-acce" name="Tank Hunters" hidden="false" targetId="c707-cf7b-113b-507b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1609,243 +1609,243 @@
           <entryLinks>
             <entryLink id="bcd1-4d36-194d-cf11" name="Rifle Grenade" hidden="false" collective="false" import="true" targetId="4492-e0f5-5aa1-5c8a" type="selectionEntry">
               <modifiers>
-                <modifier type="decrement" field="c170-64b1-b2ee-8416" value="1.0">
+                <modifier type="decrement" field="c170-64b1-b2ee-8416" value="1">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7760-49e1-f95a-c791" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7760-49e1-f95a-c791" type="greaterThan"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c170-64b1-b2ee-8416" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c170-64b1-b2ee-8416" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="75a6-5208-fc83-0b9c" name="Squad Members" hidden="false" collective="false" import="true" defaultSelectionEntryId="292f-f604-c029-2ad9">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbef-d6de-c586-6ee7" type="min"/>
-            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="336e-6a1b-cb7f-9bce" type="max"/>
+            <constraint field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbef-d6de-c586-6ee7" type="min"/>
+            <constraint field="selections" scope="parent" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="336e-6a1b-cb7f-9bce" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="b75d-4f94-b74a-4e80" name="NCO" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </modifierGroup>
               </modifierGroups>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98a3-f8f6-4bf0-b771" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d2a-11bd-c3ca-29bf" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98a3-f8f6-4bf0-b771" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d2a-11bd-c3ca-29bf" type="max"/>
               </constraints>
               <selectionEntryGroups>
                 <selectionEntryGroup id="aa08-ddb7-48cc-c43d" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="7446-2b95-206f-1777">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99af-7f4c-fe54-b533" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3075-9a85-bfd3-229f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99af-7f4c-fe54-b533" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3075-9a85-bfd3-229f" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="7446-2b95-206f-1777" name="Rifle" hidden="false" collective="false" import="true" targetId="69b8-002c-ef16-c6e4" type="selectionEntry"/>
                     <entryLink id="8859-f682-7456-8dda" name="SMG" hidden="false" collective="false" import="true" targetId="da2f-423c-1523-5126" type="selectionEntry">
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3"/>
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d1fe-a01e-650e-086f" name="Soldier with BAR" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </modifierGroup>
               </modifierGroups>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="510f-dc80-d253-b7bc" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="510f-dc80-d253-b7bc" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="5abd-b708-fda9-445a" name="Automatic Rifle" hidden="false" collective="false" import="true" targetId="1efc-f6d3-abb7-0876" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f987-3db5-3de7-bb74" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd3d-dd5e-7420-ba0b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f987-3db5-3de7-bb74" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd3d-dd5e-7420-ba0b" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="292f-f604-c029-2ad9" name="Soldier with Rifle" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </modifierGroup>
               </modifierGroups>
               <constraints>
-                <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbd5-41af-0ec9-0ee3" type="max"/>
+                <constraint field="selections" scope="parent" value="11" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbd5-41af-0ec9-0ee3" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="dafd-7544-ed16-7827" name="Rifle" hidden="false" collective="false" import="true" targetId="0a1a-55ad-a310-3cdc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f571-4e7d-93ca-c236" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c854-071a-6da5-a4cb" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f571-4e7d-93ca-c236" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c854-071a-6da5-a4cb" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="553c-537c-9bd1-9756" name="Soldier with SMG" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </modifierGroup>
               </modifierGroups>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a9f-ce04-9f87-e70e" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a9f-ce04-9f87-e70e" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="3888-81c9-fd04-34fa" name="SMG" hidden="false" collective="false" import="true" targetId="0fae-2704-edd4-5dd1" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e365-5144-79d1-5ad1" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a65-f0aa-8033-2943" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e365-5144-79d1-5ad1" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a65-f0aa-8033-2943" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7760-49e1-f95a-c791" name="Soldier with Grenade Launcher" hidden="false" collective="false" import="true" type="model">
               <modifiers>
-                <modifier type="decrement" field="cce0-a719-6572-fb5b" value="1.0">
+                <modifier type="decrement" field="cce0-a719-6572-fb5b" value="1">
                   <conditions>
-                    <condition field="selections" scope="2ce0-4c13-f637-93b3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e0b8-a9c4-96d8-4498" type="greaterThan"/>
+                    <condition field="selections" scope="2ce0-4c13-f637-93b3" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e0b8-a9c4-96d8-4498" type="greaterThan"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </modifierGroup>
               </modifierGroups>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cce0-a719-6572-fb5b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cce0-a719-6572-fb5b" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="a406-88fe-d451-1720" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="937b-3637-ac69-f44f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30d2-2b0d-8a75-5fe0" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0529-d89e-9ac6-26a1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30d2-2b0d-8a75-5fe0" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0529-d89e-9ac6-26a1" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="d80f-c79f-5769-c7ab" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="5396-a8d3-d44b-cc8c">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9f0-9f49-e26e-e32d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58f5-34d1-c536-d329" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9f0-9f49-e26e-e32d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58f5-34d1-c536-d329" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="197d-95c5-72c2-1068" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry"/>
@@ -1855,7 +1855,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bd6f-5d31-4f68-9ad8" name="M24 Chaffee" hidden="false" collective="false" import="true" type="unit">
@@ -1869,22 +1869,22 @@
         <infoLink id="275d-a9b6-e961-03e8" name="75mm HE" hidden="false" targetId="0315-8062-b1dd-4c5d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e924-4d6f-4ae2-1de9" name="New CategoryLink" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
-        <categoryLink id="c7f5-31e0-d875-2c78" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="e924-4d6f-4ae2-1de9" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
+        <categoryLink id="c7f5-31e0-d875-2c78" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="a241-a0d2-07f3-cf8b" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="1ce6-26e2-8b8b-6d55" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
-        <categoryLink id="d551-207b-10b2-cfa6" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="d551-207b-10b2-cfa6" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b533-46d7-47b5-a3a2" name="Recce" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01b1-912a-4c12-854c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01b1-912a-4c12-854c" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="9dce-62d4-2a2f-f4f8" name="Recce" hidden="false" targetId="fa0e-9e9d-0e65-1e3b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2b40-87b4-1a7d-5328" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -1893,13 +1893,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd6f-5d31-4f68-9ad8" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd6f-5d31-4f68-9ad8" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -1908,37 +1908,37 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7f25-2d39-985c-4b34" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="da3a-2d00-8ed4-18c5" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7f25-2d39-985c-4b34" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="da3a-2d00-8ed4-18c5" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="7b45-d50d-0629-d908" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="00fa-4b42-1c77-5bad" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="8843-d7e8-bc2d-97af">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10ef-ccac-acf9-a15c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b72-842e-2429-c291" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10ef-ccac-acf9-a15c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b72-842e-2429-c291" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="8843-d7e8-bc2d-97af" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="120.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="120"/>
               </costs>
             </entryLink>
             <entryLink id="f82f-cd94-65d0-6a91" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="190.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="190"/>
               </costs>
             </entryLink>
             <entryLink id="3192-f7a5-c47b-d88b" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="150.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="150"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1947,8 +1947,8 @@
       <entryLinks>
         <entryLink id="ccc8-39d7-5347-fda7" name="Turret-Mounted Light AT Gun" hidden="false" collective="false" import="true" targetId="bc28-0208-2b44-a5ac" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0954-2095-6fbb-dc52" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0da6-9a1f-8f9d-0b44" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0954-2095-6fbb-dc52" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0da6-9a1f-8f9d-0b44" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="d591-84f2-3cb9-ca8f" name="Gyro-Stabilised" hidden="false" targetId="17c2-1379-b790-b8be" type="rule"/>
@@ -1956,36 +1956,36 @@
         </entryLink>
         <entryLink id="f50c-de12-0f63-b562" name="Coaxial MMG" hidden="false" collective="false" import="true" targetId="cfd8-d421-3cd2-ab75" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9879-32d0-4d12-eedb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1af9-b7a9-f296-415b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9879-32d0-4d12-eedb" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1af9-b7a9-f296-415b" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="34bd-cd4d-c2e3-9443" name="Hull-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="f3d9-1a0f-0031-e8c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35b6-9e60-9406-b416" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc9b-7609-6408-635f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35b6-9e60-9406-b416" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc9b-7609-6408-635f" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="dcb7-5c35-321f-bba1" name="Pintle-Mounted Turret-Based HMG" hidden="false" collective="false" import="true" targetId="4d7a-e491-7f93-70d9" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbd9-b8ce-6340-7cdb" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbd9-b8ce-6340-7cdb" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
           </costs>
         </entryLink>
         <entryLink id="b04d-0c1a-67f4-ed8a" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7521-5039-e2c3-3f4b" name="M26 Pershing" hidden="false" collective="false" import="true" type="unit">
@@ -1994,8 +1994,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -2005,11 +2005,11 @@
         <infoLink id="3a37-327d-5a2c-a3fd" name="Heavy Tank" hidden="false" targetId="923d-ea2a-6016-ed02" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0660-d1c3-a76a-a811" name="New CategoryLink" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
-        <categoryLink id="0e5b-cb45-20f9-ad00" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="0660-d1c3-a76a-a811" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
+        <categoryLink id="0e5b-cb45-20f9-ad00" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="ed92-eef1-5396-7e2a" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="954e-c91c-1b9a-ab1d" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
-        <categoryLink id="2bb0-d8b1-8516-b002" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="2bb0-d8b1-8516-b002" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5c90-59c3-6b6b-f405" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -2018,13 +2018,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7521-5039-e2c3-3f4b" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7521-5039-e2c3-3f4b" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2033,37 +2033,37 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="378e-a636-2b29-5b96" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9a5-6030-d3a0-25d3" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="378e-a636-2b29-5b96" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9a5-6030-d3a0-25d3" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="9a4f-cd9a-74f8-fe1a" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="b104-3d5b-6ed6-69c0" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="7a97-39d3-9b5c-02e5">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d6f-3128-e80a-6055" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ca8-3fd4-af22-da60" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d6f-3128-e80a-6055" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ca8-3fd4-af22-da60" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="7a97-39d3-9b5c-02e5" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="316.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="316"/>
               </costs>
             </entryLink>
             <entryLink id="e1c0-d048-c447-911a" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="484.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="484"/>
               </costs>
             </entryLink>
             <entryLink id="599f-471a-4dfc-54a6" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="395.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="395"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -2072,20 +2072,20 @@
       <entryLinks>
         <entryLink id="df61-240f-f6a5-a22e" name="Coaxial MMG" hidden="false" collective="false" import="true" targetId="cfd8-d421-3cd2-ab75" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1078-c3e5-dcfa-2346" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdf7-a99a-025b-5198" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1078-c3e5-dcfa-2346" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdf7-a99a-025b-5198" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="15ce-b295-531e-a9b6" name="Hull-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="f3d9-1a0f-0031-e8c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="104e-2908-a6a1-2223" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a576-de99-a136-ba3b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="104e-2908-a6a1-2223" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a576-de99-a136-ba3b" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="1dc9-5c46-733c-4236" name="Turret-Mounted Super-Heavy AT Gun" hidden="false" collective="false" import="true" targetId="359d-ffaf-84b8-7008" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84af-9ca9-98d8-96ba" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a1e-c814-baa1-e297" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84af-9ca9-98d8-96ba" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a1e-c814-baa1-e297" type="min"/>
           </constraints>
           <infoLinks>
             <infoLink id="cd9d-9493-6a02-196e" name="Gyro-Stabilised" hidden="false" targetId="17c2-1379-b790-b8be" type="rule"/>
@@ -2093,24 +2093,24 @@
         </entryLink>
         <entryLink id="c9d6-c99d-2036-e8fc" name="Pintle-Mounted Forward-Facing HMG" hidden="false" collective="false" import="true" targetId="0fde-b247-5ea6-a771" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af9c-c9f7-842d-2503" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af9c-c9f7-842d-2503" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
           </costs>
         </entryLink>
         <entryLink id="a553-f4ad-3a55-6726" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="94dd-aeee-7f63-60eb" name="M4 Sherman T34 Calliope" hidden="false" collective="false" import="true" type="unit">
@@ -2124,11 +2124,11 @@
         <infoLink id="434e-6656-98da-3bd3" name="Multiple Launcher" hidden="false" targetId="168d-af4b-bcef-697a" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="c80d-5860-810b-423c" name="New CategoryLink" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
-        <categoryLink id="9e33-1c0b-7a80-e104" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="c80d-5860-810b-423c" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
+        <categoryLink id="9e33-1c0b-7a80-e104" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="b9fa-6a81-8427-5f1f" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="3b3d-5101-7f44-fe35" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
-        <categoryLink id="d15c-678f-5a48-e1b6" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="d15c-678f-5a48-e1b6" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d9f2-ad6b-a7ca-c3ff" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -2137,13 +2137,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="94dd-aeee-7f63-60eb" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="94dd-aeee-7f63-60eb" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2152,37 +2152,37 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="00be-f30f-0a36-7bae" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="450c-ba1a-4733-93e4" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="00be-f30f-0a36-7bae" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="450c-ba1a-4733-93e4" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="0ce8-74db-3b0f-2992" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="f93d-1e6c-ad71-a22b" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="7e72-9287-3b22-a0d9">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1f9-ee8c-e17f-037d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5890-97be-74ff-e91f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1f9-ee8c-e17f-037d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5890-97be-74ff-e91f" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="1be5-65b7-bdb0-f17d" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="250.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="250"/>
               </costs>
             </entryLink>
             <entryLink id="c3a7-cf6b-bb43-79a0" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="310.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="310"/>
               </costs>
             </entryLink>
             <entryLink id="7e72-9287-3b22-a0d9" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="200.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="200"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -2191,20 +2191,20 @@
       <entryLinks>
         <entryLink id="5ab0-9457-c1fb-bc37" name="Coaxial MMG" hidden="false" collective="false" import="true" targetId="cfd8-d421-3cd2-ab75" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f736-779b-5bd8-8b54" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f60d-61af-cfc1-0b22" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f736-779b-5bd8-8b54" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f60d-61af-cfc1-0b22" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="6c05-88d6-02d0-ad58" name="Hull-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="f3d9-1a0f-0031-e8c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bd2-701d-cfee-bb1b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2396-73ca-eca8-b6d6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bd2-701d-cfee-bb1b" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2396-73ca-eca8-b6d6" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="67ee-11f0-7a54-41ae" name="Turret-Mounted Medium AT Gun" hidden="false" collective="false" import="true" targetId="96c5-5bfc-cecc-66e9" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8528-b2f6-5bd6-15d4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7095-d00b-6743-72ac" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8528-b2f6-5bd6-15d4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7095-d00b-6743-72ac" type="min"/>
           </constraints>
           <infoLinks>
             <infoLink id="d4f3-4440-6d73-03be" name="Gyro-Stabilisers" hidden="false" targetId="fcab-ee24-e29e-5026" type="rule"/>
@@ -2213,22 +2213,22 @@
         </entryLink>
         <entryLink id="36ea-3478-b25f-4492" name="Turret-Mounted Multiple Launcher" hidden="false" collective="false" import="true" targetId="1faf-ad52-cb7f-202a" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9509-98a4-0e9d-ab84" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a72-126b-6e16-5117" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9509-98a4-0e9d-ab84" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a72-126b-6e16-5117" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="41e5-29c1-8d11-63e0" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4ea0-3d95-2460-6edf" name="M4A2 Sherman ‘Zippo’ (Crocodile) Flamethrower Tank" hidden="false" collective="false" import="true" type="unit">
@@ -2236,22 +2236,22 @@
         <infoLink id="484d-e223-938e-04d4" name="Medium Tank" hidden="false" targetId="f945-ed13-872d-e38b" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0d3a-15d9-8213-daf5" name="New CategoryLink" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
-        <categoryLink id="c3b4-9686-e20f-5198" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="0d3a-15d9-8213-daf5" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
+        <categoryLink id="c3b4-9686-e20f-5198" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="f58c-eb93-ffcf-141f" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="455e-ae22-98b4-7bb5" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
-        <categoryLink id="9d92-3c61-1be7-5215" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="9d92-3c61-1be7-5215" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="69fd-3604-d39f-a68e" name="Crocodile (External Fuel Tanks)" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81dd-f311-c979-06c0" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81dd-f311-c979-06c0" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="c6d4-08e7-10c8-12b2" name="Slow (Vehicle)" hidden="false" targetId="9e10-9ea1-508b-ae43" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="-10.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="-10"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1bdd-3369-5e9e-4dfa" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -2260,13 +2260,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ea0-3d95-2460-6edf" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ea0-3d95-2460-6edf" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2275,37 +2275,37 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b213-fd1d-368f-5821" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5cf3-795d-edbb-9b6b" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b213-fd1d-368f-5821" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5cf3-795d-edbb-9b6b" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="162b-dcfa-7541-d528" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="b054-ff18-6fc4-8919" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="fb68-9752-1aef-510f">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c271-dea4-1849-6079" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b4e-ab00-2964-44a3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c271-dea4-1849-6079" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b4e-ab00-2964-44a3" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="0c80-38c9-798b-bfda" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="175.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="175"/>
               </costs>
             </entryLink>
             <entryLink id="e5ac-21a4-0513-359d" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="210.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="210"/>
               </costs>
             </entryLink>
             <entryLink id="fb68-9752-1aef-510f" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="140.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="140"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -2314,42 +2314,42 @@
       <entryLinks>
         <entryLink id="2bb4-43c7-25ab-5aff" name="Coaxial MMG" hidden="false" collective="false" import="true" targetId="cfd8-d421-3cd2-ab75" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="337a-7bdf-95e1-188c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87de-bf87-22d6-c42e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="337a-7bdf-95e1-188c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87de-bf87-22d6-c42e" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="196b-567d-ed93-7aea" name="Hull-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="f3d9-1a0f-0031-e8c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb72-1cef-5a6e-6f74" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f0d-f9b7-79f0-205f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb72-1cef-5a6e-6f74" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f0d-f9b7-79f0-205f" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="fd45-256e-25c5-a911" name="Turret-Mounted Flamethrower (Vehicle)" hidden="false" collective="false" import="true" targetId="c440-988f-1317-e1b3" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b58-3bf2-9f8f-7260" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e21d-1352-4299-ca25" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b58-3bf2-9f8f-7260" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e21d-1352-4299-ca25" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="56d0-8030-de39-91c8" name="Pintle-Mounted Forward-Facing HMG" hidden="false" collective="false" import="true" targetId="0fde-b247-5ea6-a771" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1708-ddd8-368c-44f5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1708-ddd8-368c-44f5" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
           </costs>
         </entryLink>
         <entryLink id="1751-8d36-1de6-e622" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0cb7-3a63-7618-dc7a" name="M4A3 Sherman" hidden="false" collective="false" import="true" type="unit">
@@ -2357,11 +2357,11 @@
         <infoLink id="d7e4-f85b-4117-a753" name="Medium Tank" hidden="false" targetId="f945-ed13-872d-e38b" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0423-ae71-7667-ab80" name="New CategoryLink" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
-        <categoryLink id="c0a2-6597-8ba4-dc6c" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="0423-ae71-7667-ab80" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
+        <categoryLink id="c0a2-6597-8ba4-dc6c" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="5ad0-95d2-22a2-1cb4" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="b61f-501e-99f9-d3da" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
-        <categoryLink id="4e8d-61b7-d1ae-0213" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="4e8d-61b7-d1ae-0213" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3ed7-1b18-4c2e-2fa1" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -2370,13 +2370,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cb7-3a63-7618-dc7a" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cb7-3a63-7618-dc7a" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2385,73 +2385,73 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f64-b52e-934f-86f4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf1e-0e5e-5181-45df" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f64-b52e-934f-86f4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf1e-0e5e-5181-45df" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="1b14-0852-8d17-c621" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="168d-3e7e-f850-747a" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="2ebd-183a-1d15-2fb7">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b9e-da09-ba29-5170" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e501-5155-3d7b-d105" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b9e-da09-ba29-5170" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e501-5155-3d7b-d105" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="5f80-9f81-ef51-58a5" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="235.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="235"/>
               </costs>
             </entryLink>
             <entryLink id="2b02-8205-b9d6-812c" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="292.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="292"/>
               </costs>
             </entryLink>
             <entryLink id="2ebd-183a-1d15-2fb7" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="188.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="188"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="320e-d69e-1420-a5e9" name="Pintle Mount" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f68-d641-1951-b946" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f68-d641-1951-b946" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="8f98-8b9e-ddf0-fe1f" name="Pintle-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="3384-54f8-488f-d217" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d76-896e-ba91-ac2e" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d76-896e-ba91-ac2e" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
               </costs>
             </entryLink>
             <entryLink id="c90e-5050-912f-3ff1" name="Pintle-Mounted Turret-Based HMG" hidden="false" collective="false" import="true" targetId="4d7a-e491-7f93-70d9" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01b7-7c48-4059-3bf3" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01b7-7c48-4059-3bf3" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="ccf3-b33a-d801-5269" name="Main Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="aaa2-ab9d-63c5-5621">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d26-ce17-b336-4bc3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42b6-d7d3-3bdb-4bee" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d26-ce17-b336-4bc3" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42b6-d7d3-3bdb-4bee" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="aaa2-ab9d-63c5-5621" name="Medium AT Gun" hidden="false" collective="false" import="true" targetId="18d0-3b64-50f8-83e6" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c07-1793-1a4d-6b59" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c07-1793-1a4d-6b59" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="a6f1-c530-01ee-a6d4" name="Gyro-Stabilised" hidden="false" targetId="17c2-1379-b790-b8be" type="rule"/>
@@ -2461,26 +2461,26 @@
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="decrement" field="d66a-aa5a-74b9-e93a" value="32.0">
+                    <modifier type="decrement" field="d66a-aa5a-74b9-e93a" value="32">
                       <conditions>
-                        <condition field="selections" scope="0cb7-3a63-7618-dc7a" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
+                        <condition field="selections" scope="0cb7-3a63-7618-dc7a" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="decrement" field="d66a-aa5a-74b9-e93a" value="40.0">
+                    <modifier type="decrement" field="d66a-aa5a-74b9-e93a" value="40">
                       <conditions>
-                        <condition field="selections" scope="0cb7-3a63-7618-dc7a" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="0cb7-3a63-7618-dc7a" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="decrement" field="d66a-aa5a-74b9-e93a" value="48.0">
+                    <modifier type="decrement" field="d66a-aa5a-74b9-e93a" value="48">
                       <conditions>
-                        <condition field="selections" scope="0cb7-3a63-7618-dc7a" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="0cb7-3a63-7618-dc7a" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </modifierGroup>
               </modifierGroups>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4518-6e29-636e-b30f" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4518-6e29-636e-b30f" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="1487-51ab-3c28-c1e4" name="Gyro-Stabilised" hidden="false" targetId="17c2-1379-b790-b8be" type="rule"/>
@@ -2492,28 +2492,28 @@
       <entryLinks>
         <entryLink id="57dc-2557-8460-33b9" name="Coaxial MMG" hidden="false" collective="false" import="true" targetId="cfd8-d421-3cd2-ab75" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="894e-fea1-cdb1-ca94" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69a6-5cb4-8946-2588" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="894e-fea1-cdb1-ca94" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69a6-5cb4-8946-2588" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="1e38-85ea-c74a-dd2f" name="Hull-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="f3d9-1a0f-0031-e8c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7943-47a0-5ff0-3c67" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a66-9c2f-3611-c263" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7943-47a0-5ff0-3c67" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a66-9c2f-3611-c263" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="34ff-beb5-aaee-736a" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5c1c-5bb2-9835-beb5" name="M4A3E2 Sherman Jumbo Heavy Assault Tank" hidden="false" collective="false" import="true" type="unit">
@@ -2522,8 +2522,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -2534,11 +2534,11 @@
         <infoLink id="5620-e915-6cee-afbf" name="Slow (Vehicle)" hidden="false" targetId="9e10-9ea1-508b-ae43" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="be15-d593-9c4b-e430" name="New CategoryLink" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
-        <categoryLink id="a2ed-8856-18dc-1fd5" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="be15-d593-9c4b-e430" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
+        <categoryLink id="a2ed-8856-18dc-1fd5" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="dde2-3a12-3ee3-b61d" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="29d7-fc82-bea1-885c" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
-        <categoryLink id="bcf5-8d22-d4b6-2216" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="bcf5-8d22-d4b6-2216" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3115-ac70-e843-63fc" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -2547,13 +2547,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c1c-5bb2-9835-beb5" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c1c-5bb2-9835-beb5" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2562,45 +2562,45 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b2a-5086-cd13-1e99" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="008b-ab9d-79b3-9a27" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b2a-5086-cd13-1e99" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="008b-ab9d-79b3-9a27" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="54d8-ab67-bb83-0448" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="33ca-7568-5fb5-3412" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="d0c9-bfdd-522d-01fc">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a62a-e844-e15c-67f7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60c2-6ac6-5be4-0eda" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a62a-e844-e15c-67f7" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60c2-6ac6-5be4-0eda" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="5bec-a7ec-c408-ff70" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="275.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="275"/>
               </costs>
             </entryLink>
             <entryLink id="4f27-d0aa-269b-7f50" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="338.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="338"/>
               </costs>
             </entryLink>
             <entryLink id="d0c9-bfdd-522d-01fc" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="222.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="222"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="9932-bd61-e769-876d" name="Turret Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="5d6c-3c0f-f195-bf8b">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e73-cc0b-e60e-7f86" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49fc-e4b6-aa0d-609b" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e73-cc0b-e60e-7f86" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49fc-e4b6-aa0d-609b" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="5d6c-3c0f-f195-bf8b" name="Turret-Mounted Medium AT Gun" hidden="false" collective="false" import="true" targetId="96c5-5bfc-cecc-66e9" type="selectionEntry">
@@ -2611,7 +2611,7 @@
             </entryLink>
             <entryLink id="71c8-ee85-9739-0e05" name="Turret-Mounted Heavy AT Gun" hidden="false" collective="false" import="true" targetId="3296-6844-2b99-aa77" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="35.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="35"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -2620,36 +2620,36 @@
       <entryLinks>
         <entryLink id="dc32-f3c4-9a82-79a5" name="Coaxial MMG" hidden="false" collective="false" import="true" targetId="cfd8-d421-3cd2-ab75" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccb2-5e67-028e-54d6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b03-24af-e446-08af" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccb2-5e67-028e-54d6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b03-24af-e446-08af" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="9e2c-6293-598a-c90e" name="Hull-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="f3d9-1a0f-0031-e8c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22e7-5bbb-73de-5b29" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e45b-f644-3033-0ba5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22e7-5bbb-73de-5b29" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e45b-f644-3033-0ba5" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="b6d4-0b9f-860a-d56d" name="Pintle-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="3384-54f8-488f-d217" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb77-01ca-02c8-5a88" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb77-01ca-02c8-5a88" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
           </costs>
         </entryLink>
         <entryLink id="55bf-4b7b-319a-9897" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fcb0-ce95-633d-b154" name="M4A9 Sherman-T" hidden="false" collective="false" import="true" type="unit">
@@ -2657,11 +2657,11 @@
         <infoLink id="e15b-97ab-b6cd-08d2" name="Medium Tank" hidden="false" targetId="f945-ed13-872d-e38b" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8f43-f45f-0ed9-8564" name="New CategoryLink" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
-        <categoryLink id="6708-b4c3-db39-457f" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="8f43-f45f-0ed9-8564" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
+        <categoryLink id="6708-b4c3-db39-457f" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="ddb9-4d2f-5dbc-ac82" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="5307-f961-98c9-899f" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
-        <categoryLink id="6983-b03c-6dc5-bf5d" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="6983-b03c-6dc5-bf5d" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ab6a-1e11-377c-cad8" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -2670,13 +2670,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fcb0-ce95-633d-b154" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fcb0-ce95-633d-b154" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2685,55 +2685,55 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3d4e-d496-5c91-4f45" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6b42-37d0-a95b-0163" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3d4e-d496-5c91-4f45" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6b42-37d0-a95b-0163" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="1bae-344b-ade2-4294" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="5e66-c53f-3abe-0757" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="3fe1-4fb1-b37d-5ad0">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c487-4b38-ecde-715b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdca-731a-1a9d-c1de" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c487-4b38-ecde-715b" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdca-731a-1a9d-c1de" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="3fe1-4fb1-b37d-5ad0" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="210.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="210"/>
               </costs>
             </entryLink>
             <entryLink id="364c-6000-f52e-e5a5" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="260.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="260"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="d9d7-fe40-b57b-c5bf" name="Pintle Mount" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29f0-9159-bc77-052d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29f0-9159-bc77-052d" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="6dd6-0ac4-277c-3d22" name="Pintle-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="3384-54f8-488f-d217" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1c6-bdea-edd4-c879" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1c6-bdea-edd4-c879" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
               </costs>
             </entryLink>
             <entryLink id="860b-a66c-f11e-5ea9" name="Pintle-Mounted Turret-Based HMG" hidden="false" collective="false" import="true" targetId="4d7a-e491-7f93-70d9" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcc6-c9d6-cbf9-7805" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcc6-c9d6-cbf9-7805" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -2742,28 +2742,28 @@
       <entryLinks>
         <entryLink id="1a03-2bee-579b-57cf" name="Hull-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="f3d9-1a0f-0031-e8c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07ce-bc47-a7c4-a56f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fd2-3ca7-7b90-f782" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07ce-bc47-a7c4-a56f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fd2-3ca7-7b90-f782" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="58e1-2e4e-d337-f65d" name="Turret-Mounted M17 Tesla Cannon" hidden="false" collective="false" import="true" targetId="37e8-6e69-9735-81d7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1689-5006-7971-1836" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa8e-80a9-73e2-cc5a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1689-5006-7971-1836" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa8e-80a9-73e2-cc5a" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="e708-3618-26aa-2a86" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ea6f-9515-2cde-3261" name="M5A1 Stuart" hidden="false" collective="false" import="true" type="unit">
@@ -2776,11 +2776,11 @@
         <infoLink id="1c54-68d8-c481-34c3" name="Light Tank" hidden="false" targetId="5fe1-b45c-ad99-58cc" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0631-8d2e-2226-e9b9" name="New CategoryLink" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
-        <categoryLink id="28ff-3d52-c08f-6309" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="0631-8d2e-2226-e9b9" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
+        <categoryLink id="28ff-3d52-c08f-6309" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="b036-a5ea-0c34-9ed3" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="7ba5-3794-295d-b850" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
-        <categoryLink id="e2e7-5454-80ad-f6f7" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="e2e7-5454-80ad-f6f7" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e5e2-3eed-0cc4-80cb" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -2789,13 +2789,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ea6f-9515-2cde-3261" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ea6f-9515-2cde-3261" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -2804,60 +2804,60 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c99b-3ca4-e0be-77ac" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="62a1-9254-04d0-ffc9" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c99b-3ca4-e0be-77ac" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="62a1-9254-04d0-ffc9" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="6607-2db5-424b-4866" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="c83d-1180-3e7c-d572" name="Pintle Mount" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83f0-e5fb-70c7-7cc9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83f0-e5fb-70c7-7cc9" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="136e-848f-73cc-aa38" name="Pintle-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="3384-54f8-488f-d217" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6a9-65e3-68c5-797a" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6a9-65e3-68c5-797a" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
               </costs>
             </entryLink>
             <entryLink id="d7a3-29e5-4ffb-8eac" name="Pintle-Mounted Turret-Based HMG" hidden="false" collective="false" import="true" targetId="4d7a-e491-7f93-70d9" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f793-ec4b-cad2-b675" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f793-ec4b-cad2-b675" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="6d6e-3f9b-6aef-5030" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="151e-5cd8-1f6c-3943">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95bd-3318-54d1-4e00" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1448-dc8b-5d50-ac83" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95bd-3318-54d1-4e00" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1448-dc8b-5d50-ac83" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="151e-5cd8-1f6c-3943" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="124.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="124"/>
               </costs>
             </entryLink>
             <entryLink id="2843-fcb6-cf4c-8a1a" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="196.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="196"/>
               </costs>
             </entryLink>
             <entryLink id="10ff-d23f-7d46-a230" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="155.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="155"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -2866,8 +2866,8 @@
       <entryLinks>
         <entryLink id="fce6-47e4-1fb5-a4e6" name="Turret-Mounted Light AT Gun" hidden="false" collective="false" import="true" targetId="bc28-0208-2b44-a5ac" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b015-4c01-0148-a550" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70d8-4866-dc5c-6a80" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b015-4c01-0148-a550" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70d8-4866-dc5c-6a80" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="26dd-2fc4-8e7c-fba4" name="Gyro-Stabilisers" hidden="false" targetId="fcab-ee24-e29e-5026" type="rule"/>
@@ -2875,67 +2875,67 @@
         </entryLink>
         <entryLink id="24c0-74ec-5ed3-6974" name="Coaxial MMG" hidden="false" collective="false" import="true" targetId="cfd8-d421-3cd2-ab75" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51c8-cc23-a9a0-8c7c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aed8-85d6-5e80-6191" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51c8-cc23-a9a0-8c7c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aed8-85d6-5e80-6191" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="8941-2ace-0cbf-552f" name="Hull-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="f3d9-1a0f-0031-e8c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf73-e19c-1bee-48a1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ab5-b8cd-bf3b-2164" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf73-e19c-1bee-48a1" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ab5-b8cd-bf3b-2164" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="1fd5-e0ae-03da-1f37" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7314-2de7-130e-a9d9" name="Marine Squad" publicationId="9a47-ac76-pubN65838" page="50" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+            <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="7bca-ec21-b04f-9e1c" name="New CategoryLink" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
+        <categoryLink id="7bca-ec21-b04f-9e1c" name="Infantry Squads" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
         <categoryLink id="dd14-f98d-facb-8108" name="Marine, Paragon, Paragon Support squads only" hidden="false" targetId="2fa0-e678-ad52-d310" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0c71-69fa-9deb-416f" name="Anti-Tank Grenades" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="2.0">
+            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="2">
               <repeats>
-                <repeat field="selections" scope="7314-2de7-130e-a9d9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="7314-2de7-130e-a9d9" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="178f-72e3-7430-edd8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="178f-72e3-7430-edd8" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="5f75-7f0b-46b6-3fe4" name="Tank Hunters" hidden="false" targetId="c707-cf7b-113b-507b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="9725-7df4-9311-dc01" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="62bb-1288-174a-1c90">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da15-ec43-362c-329a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68a4-3afd-984c-423e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da15-ec43-362c-329a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68a4-3afd-984c-423e" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="62bb-1288-174a-1c90" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry"/>
@@ -2946,276 +2946,276 @@
           <entryLinks>
             <entryLink id="abfc-d823-2785-6c4c" name="Rifle Grenade" hidden="false" collective="false" import="true" targetId="4492-e0f5-5aa1-5c8a" type="selectionEntry">
               <modifiers>
-                <modifier type="decrement" field="8e5f-a070-1848-e581" value="1.0">
+                <modifier type="decrement" field="8e5f-a070-1848-e581" value="1">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d641-e289-5332-8340" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d641-e289-5332-8340" type="greaterThan"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e5f-a070-1848-e581" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e5f-a070-1848-e581" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="23b3-fc65-7259-08d8" name="Squad Members" hidden="false" collective="false" import="true" defaultSelectionEntryId="6ac1-60a0-f2b6-5027">
           <constraints>
-            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a0c-4717-c4b3-8d57" type="min"/>
-            <constraint field="selections" scope="parent" value="13.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af92-b693-be6c-6cbe" type="max"/>
+            <constraint field="selections" scope="parent" value="7" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a0c-4717-c4b3-8d57" type="min"/>
+            <constraint field="selections" scope="parent" value="13" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af92-b693-be6c-6cbe" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="a44f-86ac-d99b-0d9c" name="NCO" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </modifierGroup>
               </modifierGroups>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85d7-adef-afee-8509" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18f9-498a-24f0-cd79" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85d7-adef-afee-8509" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18f9-498a-24f0-cd79" type="max"/>
               </constraints>
               <selectionEntryGroups>
                 <selectionEntryGroup id="f6f7-f3d5-f795-5c03" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="f0d9-0e07-c550-3b57">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="160f-544e-d420-e8ab" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf4b-8e2e-7226-b90f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="160f-544e-d420-e8ab" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf4b-8e2e-7226-b90f" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="f0d9-0e07-c550-3b57" name="Rifle" hidden="false" collective="false" import="true" targetId="69b8-002c-ef16-c6e4" type="selectionEntry"/>
                     <entryLink id="dbf9-45ab-7c03-39c0" name="SMG" hidden="false" collective="false" import="true" targetId="da2f-423c-1523-5126" type="selectionEntry">
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3"/>
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c335-79de-7a66-a202" name="Soldier with BAR" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </modifierGroup>
               </modifierGroups>
               <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fdd-15c9-4bb1-8707" type="max"/>
+                <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fdd-15c9-4bb1-8707" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="008a-5e60-9464-2b92" name="Automatic Rifle" hidden="false" collective="false" import="true" targetId="1efc-f6d3-abb7-0876" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d491-9adc-e75a-117d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d503-38cc-52d0-079a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d491-9adc-e75a-117d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d503-38cc-52d0-079a" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ac1-60a0-f2b6-5027" name="Soldier with Rifle" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </modifierGroup>
               </modifierGroups>
               <constraints>
-                <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd0a-4500-9020-4f5a" type="max"/>
+                <constraint field="selections" scope="parent" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd0a-4500-9020-4f5a" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="9c6d-0222-23e7-d542" name="Rifle" hidden="false" collective="false" import="true" targetId="0a1a-55ad-a310-3cdc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d620-94ed-195f-6426" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ad7-a1e8-a72c-ace3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d620-94ed-195f-6426" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ad7-a1e8-a72c-ace3" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a584-ecb8-0c91-8229" name="Soldier with SMG" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </modifierGroup>
               </modifierGroups>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1129-5fb8-1a80-6183" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1129-5fb8-1a80-6183" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="744c-dad9-1e87-52b2" name="SMG" hidden="false" collective="false" import="true" targetId="0fae-2704-edd4-5dd1" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c1f-1768-137f-b2cf" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6be3-4df3-461d-bd82" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c1f-1768-137f-b2cf" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6be3-4df3-461d-bd82" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d641-e289-5332-8340" name="Soldier with Grenade Launcher" hidden="false" collective="false" import="true" type="model">
               <modifiers>
-                <modifier type="decrement" field="5107-bc2f-5021-f4c5" value="1.0">
+                <modifier type="decrement" field="5107-bc2f-5021-f4c5" value="1">
                   <conditions>
-                    <condition field="selections" scope="7314-2de7-130e-a9d9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a5-8a0f-fd53-9225" type="greaterThan"/>
+                    <condition field="selections" scope="7314-2de7-130e-a9d9" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a5-8a0f-fd53-9225" type="greaterThan"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </modifierGroup>
               </modifierGroups>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5107-bc2f-5021-f4c5" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5107-bc2f-5021-f4c5" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="df68-8ce3-e48b-c152" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="937b-3637-ac69-f44f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96cc-ca4a-4c5a-bbb6" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15b5-6a0c-63c6-1978" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96cc-ca4a-4c5a-bbb6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15b5-6a0c-63c6-1978" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f263-4db5-491c-aad8" name="Soldier with Shotgun" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </modifierGroup>
               </modifierGroups>
               <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c365-1b7d-871a-f86f" type="max"/>
+                <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c365-1b7d-871a-f86f" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="7c8c-39fd-2f96-6a0c" name="Shotgun" hidden="false" collective="false" import="true" targetId="7a5f-1b47-e5bf-3081" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2aa-1ac6-b25b-cfa8" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="810f-371d-0854-08ac" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2aa-1ac6-b25b-cfa8" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="810f-371d-0854-08ac" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="de88-e79f-32c8-08d4" name="Sidearms" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4ab-701d-e811-2346" type="max"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4ab-701d-e811-2346" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="d4f9-1f2a-caf4-9c17" name="Pistol" hidden="false" collective="false" import="true" targetId="1c96-bad3-b18b-1fe3" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="1.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="1"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c531-4bdf-eb22-c5d9" name="Medic" publicationId="9a47-ac76-pubN65784" page="147" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="0e06-2ea5-a6be-5edc" name="New CategoryLink" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
+        <categoryLink id="0e06-2ea5-a6be-5edc" name="Headquarters" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
         <categoryLink id="a37c-5560-73ee-d5b2" name="Medic" hidden="false" targetId="64b3-a04b-d6d0-add2" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="18b7-3f16-9f5b-efc6" name="Medic" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbd9-507d-84e8-d861" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf93-c1d9-6118-2afc" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbd9-507d-84e8-d861" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf93-c1d9-6118-2afc" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="ed64-30ec-2a27-8444" name="Medic" hidden="false" targetId="5125-e49a-6442-19ef" type="rule"/>
@@ -3224,7 +3224,7 @@
           <selectionEntryGroups>
             <selectionEntryGroup id="be0f-9956-6265-b7f2" name="Weapon" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8cc-88e9-dbfd-d1cd" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8cc-88e9-dbfd-d1cd" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="c855-e296-c674-045d" name="Pistol" hidden="false" collective="false" import="true" targetId="d7b1-e557-88f6-1ac4" type="selectionEntry"/>
@@ -3232,14 +3232,14 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="30.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="30"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="d0f8-8df6-d492-9505" name="Additional Men" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70ad-f64f-a437-79fd" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70ad-f64f-a437-79fd" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="21a6-ac11-5adc-c86f" name="Junior Medical Staff" hidden="false" collective="true" import="true" type="model">
@@ -3249,7 +3249,7 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="f26f-59f2-687a-f28b" name="Weapon" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8f3-9237-eac2-18d7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8f3-9237-eac2-18d7" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="5b96-6b00-31be-1caf" name="Pistol" hidden="false" collective="false" import="true" targetId="d7b1-e557-88f6-1ac4" type="selectionEntry"/>
@@ -3257,51 +3257,51 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6341-21ac-4160-613f" name="Officer" page="147" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="ae37-8809-fabb-7d90" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+            <condition field="selections" scope="ae37-8809-fabb-7d90" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="761c-4fae-e82f-85fd" name="New CategoryLink" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
+        <categoryLink id="761c-4fae-e82f-85fd" name="Headquarters" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
         <categoryLink id="b837-7dd9-8186-a52b" name="Commander" hidden="false" targetId="fb1a-cb93-a427-51cf" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="d3cf-6378-f1e2-f8c9" name="Additonal Men" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="987d-627d-d99e-618c" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="987d-627d-d99e-618c" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="11be-e0ea-e808-6581" name="Soldier" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="6341-21ac-4160-613f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="6341-21ac-4160-613f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7">
                       <conditions>
-                        <condition field="selections" scope="6341-21ac-4160-613f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
+                        <condition field="selections" scope="6341-21ac-4160-613f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="6341-21ac-4160-613f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="6341-21ac-4160-613f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3310,8 +3310,8 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="97c8-6e12-5716-5c9c" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="40ce-7302-df64-88f1">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55f1-0bb7-50e4-ee15" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d964-d255-2d8a-a371" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55f1-0bb7-50e4-ee15" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d964-d255-2d8a-a371" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="446a-8dc8-a810-a09b" name="Pistol" hidden="false" collective="false" import="true" targetId="d7b1-e557-88f6-1ac4" type="selectionEntry"/>
@@ -3321,15 +3321,15 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="b2e9-95b3-2ef2-dd21" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="ecd5-0e6f-9bed-8e13">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac73-c531-439f-bb91" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e3d-c358-3815-1aac" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac73-c531-439f-bb91" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e3d-c358-3815-1aac" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="ecd5-0e6f-9bed-8e13" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry"/>
@@ -3339,27 +3339,27 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="3d06-8024-9a37-f009" name="Officer" hidden="false" collective="false" import="true" defaultSelectionEntryId="f62c-2c98-af81-857e">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="765b-169d-4da3-268a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0cc-732c-67b2-bf03" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="765b-169d-4da3-268a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0cc-732c-67b2-bf03" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="f62c-2c98-af81-857e" name="Second Lieutenant" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="50.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="50">
                       <conditions>
-                        <condition field="selections" scope="6341-21ac-4160-613f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="6341-21ac-4160-613f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="35.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="35">
                       <conditions>
-                        <condition field="selections" scope="6341-21ac-4160-613f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
+                        <condition field="selections" scope="6341-21ac-4160-613f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="65.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="65">
                       <conditions>
-                        <condition field="selections" scope="6341-21ac-4160-613f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="6341-21ac-4160-613f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3372,8 +3372,8 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="53f5-8ac3-c3bb-5239" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a9b8-8bc5-09fb-306e">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2d4-f412-e697-3784" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9515-ae83-b305-dcd4" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2d4-f412-e697-3784" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9515-ae83-b305-dcd4" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="51a5-9897-15aa-6c18" name="Pistol" hidden="false" collective="false" import="true" targetId="d7b1-e557-88f6-1ac4" type="selectionEntry"/>
@@ -3383,26 +3383,26 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a380-9500-fcab-587c" name="First Lieutenant" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="75.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="75">
                       <conditions>
-                        <condition field="selections" scope="6341-21ac-4160-613f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="6341-21ac-4160-613f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="60.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="60">
                       <conditions>
-                        <condition field="selections" scope="6341-21ac-4160-613f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
+                        <condition field="selections" scope="6341-21ac-4160-613f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="90.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="90">
                       <conditions>
-                        <condition field="selections" scope="6341-21ac-4160-613f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d5c-9b28-a486-2d1a" type="greaterThan"/>
+                        <condition field="selections" scope="6341-21ac-4160-613f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d5c-9b28-a486-2d1a" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -3415,8 +3415,8 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="f1b1-f836-a9a0-46e5" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="0834-2622-0082-d0b2">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27fb-8730-b370-625f" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c3d-01d6-926f-a8c7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27fb-8730-b370-625f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c3d-01d6-926f-a8c7" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="d49f-d2d8-46a7-ad77" name="Pistol" hidden="false" collective="false" import="true" targetId="d7b1-e557-88f6-1ac4" type="selectionEntry"/>
@@ -3426,14 +3426,14 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="843a-57a5-dd66-a8ab" name="Paragon Support Squad" publicationId="9a47-ac76-pubN65838" page="50" hidden="false" collective="false" import="true" type="unit">
@@ -3443,7 +3443,7 @@
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="7ecb-e8d7-d299-374d" name="New CategoryLink" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
+        <categoryLink id="7ecb-e8d7-d299-374d" name="Infantry Squads" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
         <categoryLink id="a2de-3b49-beff-8886" name="Marine, Paragon, Paragon Support squads only" hidden="false" targetId="2fa0-e678-ad52-d310" primary="false"/>
         <categoryLink id="e7e8-f25d-48ab-b5bf" name="Airborne, Firefly, Paragon, and Paragon Support squads" hidden="false" targetId="3d5f-584d-0742-f29d" primary="false"/>
         <categoryLink id="414d-8a4d-ce3d-3027" name="Heavy Infantry, Paragon, and Paragon Support squads" hidden="false" targetId="9cf3-0bc0-7974-b411" primary="false"/>
@@ -3451,34 +3451,34 @@
       <selectionEntries>
         <selectionEntry id="eba2-4298-ea46-f419" name="Elite" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="11.0">
+            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="11">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9516-4dc0-21a6-5c0f" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9516-4dc0-21a6-5c0f" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="b790-c698-5cee-9dff" name="Elite" hidden="false" targetId="5ee9-9b1c-5ea8-b5a4" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="5823-86af-09b8-5ded" name="Squad Members" hidden="false" collective="false" import="true" defaultSelectionEntryId="b6bc-c48a-acde-731c">
           <constraints>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c890-fac3-2b82-7c1a" type="min"/>
-            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb90-abb4-b2ee-d55e" type="max"/>
+            <constraint field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c890-fac3-2b82-7c1a" type="min"/>
+            <constraint field="selections" scope="parent" value="11" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb90-abb4-b2ee-d55e" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="b4b2-f9fc-cbae-dca8" name="Paragon NCO" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72ed-9058-b972-85bf" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32aa-cecb-dd5d-8aad" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72ed-9058-b972-85bf" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32aa-cecb-dd5d-8aad" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="ce99-54ee-b8f5-cd31" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -3489,8 +3489,8 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="65e1-84fa-7190-ec2c" name="Paragon Type" hidden="false" collective="false" import="true">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8c6-7dc5-93f4-64c7" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d03-dcb8-d39a-f84f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8c6-7dc5-93f4-64c7" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d03-dcb8-d39a-f84f" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="b40d-09a1-f512-4ca8" name="Paragon NCO D (Automatic Rifle &amp; Tough Fighter; Stubborn)" hidden="false" collective="false" import="true" type="upgrade">
@@ -3501,13 +3501,13 @@
                       <entryLinks>
                         <entryLink id="0c5a-01c1-223b-805a" name="Automatic Rifle" hidden="false" collective="false" import="true" targetId="1efc-f6d3-abb7-0876" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9686-5d68-fe8e-31fa" type="max"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ca0-dc64-d056-6a17" type="min"/>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9686-5d68-fe8e-31fa" type="max"/>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ca0-dc64-d056-6a17" type="min"/>
                           </constraints>
                         </entryLink>
                       </entryLinks>
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9b56-7dd7-6fcf-530a" name="Paragon NCO B (SMG &amp; Tooth and Claw; Tough Fighters)" hidden="false" collective="false" import="true" type="upgrade">
@@ -3528,13 +3528,13 @@
                       <entryLinks>
                         <entryLink id="7343-b0a0-72f0-61fe" name="SMG" hidden="false" collective="false" import="true" targetId="0fae-2704-edd4-5dd1" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84ce-6b42-ad5e-208a" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48ba-e0f9-234c-242b" type="max"/>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84ce-6b42-ad5e-208a" type="min"/>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48ba-e0f9-234c-242b" type="max"/>
                           </constraints>
                         </entryLink>
                       </entryLinks>
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6af7-0165-d69c-a7ed" name="Paragon NCO C (Pistol &amp; Tooth and Claw; Fanatics)" hidden="false" collective="false" import="true" type="upgrade">
@@ -3555,13 +3555,13 @@
                       <entryLinks>
                         <entryLink id="a7dd-64d8-6570-4c32" name="Pistol" hidden="false" collective="false" import="true" targetId="1c96-bad3-b18b-1fe3" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab8d-012a-f9a6-23b2" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebe2-3729-2b42-b8df" type="max"/>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab8d-012a-f9a6-23b2" type="min"/>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebe2-3729-2b42-b8df" type="max"/>
                           </constraints>
                         </entryLink>
                       </entryLinks>
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e968-161f-590d-3197" name="Paragon NCO A (SMG &amp; Strong; Tank Hunters)" hidden="false" collective="false" import="true" type="upgrade">
@@ -3572,25 +3572,25 @@
                       <entryLinks>
                         <entryLink id="78b1-e50e-ec78-b028" name="SMG" hidden="false" collective="false" import="true" targetId="0fae-2704-edd4-5dd1" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fac4-8233-02ab-e624" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed9c-1b34-0a1a-d3a7" type="max"/>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fac4-8233-02ab-e624" type="min"/>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed9c-1b34-0a1a-d3a7" type="max"/>
                           </constraints>
                         </entryLink>
                       </entryLinks>
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e533-7043-6490-baca" name="Soldier with BAR" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01f4-97e3-3d9b-bf8c" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01f4-97e3-3d9b-bf8c" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="8aad-1ab3-4de0-a836" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -3599,21 +3599,21 @@
               <entryLinks>
                 <entryLink id="bde3-9ab8-21ae-a30f" name="Automatic Rifle" hidden="false" collective="false" import="true" targetId="1efc-f6d3-abb7-0876" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b6d-910a-5fae-fcb9" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="129b-d030-3a3e-8987" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b6d-910a-5fae-fcb9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="129b-d030-3a3e-8987" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b6bc-c48a-acde-731c" name="Soldier with Rifle" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41b6-a2e4-3a7f-7128" type="max"/>
+                <constraint field="selections" scope="parent" value="10" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41b6-a2e4-3a7f-7128" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="b2ef-25e0-b6ed-6b49" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -3622,18 +3622,18 @@
               <entryLinks>
                 <entryLink id="ba37-6921-c8f8-853a" name="Rifle" hidden="false" collective="false" import="true" targetId="0a1a-55ad-a310-3cdc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9e7-12c8-6be9-957d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f41-051e-e2a2-5dc8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9e7-12c8-6be9-957d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f41-051e-e2a2-5dc8" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b508-eae1-1b64-17b4" name="Soldier with SMG" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a158-a5ba-1918-9ea6" type="max"/>
+                <constraint field="selections" scope="parent" value="10" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a158-a5ba-1918-9ea6" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="0a83-7fd9-0be6-f2c0" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -3642,21 +3642,21 @@
               <entryLinks>
                 <entryLink id="3be0-f146-8901-b3d2" name="SMG" hidden="false" collective="false" import="true" targetId="0fae-2704-edd4-5dd1" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b582-36b0-edba-e02f" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1b9-e817-6f94-bb89" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b582-36b0-edba-e02f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1b9-e817-6f94-bb89" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ae1b-c3d5-4005-d2f6" name="Soldier with Heavy Tesla Rifle" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7aa1-b517-a75f-4a37" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7aa1-b517-a75f-4a37" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="2a41-ae60-abdb-8888" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -3665,21 +3665,21 @@
               <entryLinks>
                 <entryLink id="515a-143a-8d9f-922a" name="Heavy Tesla Rifle" hidden="false" collective="false" import="true" targetId="3e91-0151-f107-266c" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3013-92dc-e0b3-f4c2" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="040d-d4ec-0154-bc44" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3013-92dc-e0b3-f4c2" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="040d-d4ec-0154-bc44" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c0a-84be-a99e-f353" name="Soldier with Grenade Launcher" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ca8-eb05-a79b-e463" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ca8-eb05-a79b-e463" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="d77b-d0ac-a85a-93f4" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -3688,30 +3688,30 @@
               <entryLinks>
                 <entryLink id="e970-62a5-ed4d-282e" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="937b-3637-ac69-f44f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fa5-7d55-ed2b-a167" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d85d-2a01-539d-3220" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fa5-7d55-ed2b-a167" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d85d-2a01-539d-3220" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="62a5-9ebe-ce69-0d02" name="Airborne Infantry Squad" page="148" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+            <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -3719,26 +3719,26 @@
         <infoLink id="4137-d6f5-b87b-e96e" name="Stubborn" hidden="false" targetId="67c4-b526-4222-9d1a" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="fab8-c516-3c17-8dca" name="New CategoryLink" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
+        <categoryLink id="fab8-c516-3c17-8dca" name="Infantry Squads" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
         <categoryLink id="6625-160a-b0fc-6f3e" name="Airborne, Firefly, Paragon, and Paragon Support squads" hidden="false" targetId="3d5f-584d-0742-f29d" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ec07-3a88-28aa-0932" name="Anti-Tank Grenades" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="2.0">
+            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="2">
               <repeats>
-                <repeat field="selections" scope="62a5-9ebe-ce69-0d02" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="62a5-9ebe-ce69-0d02" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5996-3413-d3ae-8f43" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5996-3413-d3ae-8f43" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="b9ea-dad9-ccf5-afaa" name="Tank Hunters" hidden="false" targetId="c707-cf7b-113b-507b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -3747,31 +3747,31 @@
           <entryLinks>
             <entryLink id="8caf-6d9a-eaa2-1ace" name="Rifle Grenade" hidden="false" collective="false" import="true" targetId="4492-e0f5-5aa1-5c8a" type="selectionEntry">
               <modifiers>
-                <modifier type="decrement" field="e040-fcb5-21db-d1a5" value="1.0">
+                <modifier type="decrement" field="e040-fcb5-21db-d1a5" value="1">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53e3-7da9-288c-8c03" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53e3-7da9-288c-8c03" type="greaterThan"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e040-fcb5-21db-d1a5" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e040-fcb5-21db-d1a5" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="4548-40a5-92b6-27c5" name="Squad Members" hidden="false" collective="false" import="true" defaultSelectionEntryId="43fd-2995-d2db-c5d6">
           <constraints>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da9f-9340-d305-daaa" type="min"/>
-            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a01-3076-1f37-7a2c" type="max"/>
+            <constraint field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da9f-9340-d305-daaa" type="min"/>
+            <constraint field="selections" scope="parent" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a01-3076-1f37-7a2c" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="fa22-c74e-b49d-0786" name="NCO" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="066b-62a4-f275-2f20" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4604-de40-075b-bd1b" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="066b-62a4-f275-2f20" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4604-de40-075b-bd1b" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="005d-dd4d-da30-ab77" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -3779,26 +3779,26 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="6bdf-9dc8-15d8-cfb5" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="5306-32a0-d13f-2b15">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4454-5273-5c1b-5eda" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61b3-90b5-7102-4648" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4454-5273-5c1b-5eda" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61b3-90b5-7102-4648" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="5306-32a0-d13f-2b15" name="Rifle" hidden="false" collective="false" import="true" targetId="69b8-002c-ef16-c6e4" type="selectionEntry"/>
                     <entryLink id="76d9-d48f-1368-6f53" name="SMG" hidden="false" collective="false" import="true" targetId="da2f-423c-1523-5126" type="selectionEntry">
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3"/>
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51e7-923a-4eda-4a2e" name="Soldier with BAR" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ea3-e0a3-c842-e99c" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ea3-e0a3-c842-e99c" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="7e74-2b38-13c7-4132" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -3806,21 +3806,21 @@
               <entryLinks>
                 <entryLink id="09e6-6ff8-5d0a-dfa9" name="Automatic Rifle" hidden="false" collective="false" import="true" targetId="1efc-f6d3-abb7-0876" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31cd-4552-8de2-b1d0" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2141-39e5-6545-1840" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31cd-4552-8de2-b1d0" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2141-39e5-6545-1840" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="43fd-2995-d2db-c5d6" name="Soldier with Rifle" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7a3-e09e-cc9c-a484" type="max"/>
+                <constraint field="selections" scope="parent" value="11" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7a3-e09e-cc9c-a484" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="fcb0-c77f-226c-81bd" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -3828,18 +3828,18 @@
               <entryLinks>
                 <entryLink id="2d58-34ce-8c84-847b" name="Rifle" hidden="false" collective="false" import="true" targetId="0a1a-55ad-a310-3cdc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7843-3da0-5a16-cb9d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ceec-c4f2-53b3-be32" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7843-3da0-5a16-cb9d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ceec-c4f2-53b3-be32" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cb75-6abd-c9b6-463a" name="Soldier with SMG" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67f7-8f4f-b5d8-7415" type="max"/>
+                <constraint field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67f7-8f4f-b5d8-7415" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="2ec4-c53d-0165-4d8d" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -3847,28 +3847,28 @@
               <entryLinks>
                 <entryLink id="d464-8b2d-41d8-5dcb" name="SMG" hidden="false" collective="false" import="true" targetId="0fae-2704-edd4-5dd1" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c962-9066-d1bb-125f" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92c2-70ca-9de3-6088" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c962-9066-d1bb-125f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92c2-70ca-9de3-6088" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53e3-7da9-288c-8c03" name="Soldier with Grenade Launcher" hidden="false" collective="false" import="true" type="model">
               <modifiers>
-                <modifier type="decrement" field="d3be-7a6a-2683-56ed" value="1.0">
+                <modifier type="decrement" field="d3be-7a6a-2683-56ed" value="1">
                   <conditions>
-                    <condition field="selections" scope="62a5-9ebe-ce69-0d02" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4941-fa15-a3a7-f212" type="greaterThan"/>
+                    <condition field="selections" scope="62a5-9ebe-ce69-0d02" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4941-fa15-a3a7-f212" type="greaterThan"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3be-7a6a-2683-56ed" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3be-7a6a-2683-56ed" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="82c9-916b-13db-9948" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -3876,21 +3876,21 @@
               <entryLinks>
                 <entryLink id="74ad-c210-4514-1d30" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="937b-3637-ac69-f44f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1885-0265-5cf9-0ba1" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="439c-6cd6-7c1e-a2c3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1885-0265-5cf9-0ba1" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="439c-6cd6-7c1e-a2c3" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c10-b6c3-f41f-e2f7" name="Soldier with LMG" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d3b-5fd3-9284-6516" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d3b-5fd3-9284-6516" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="aec5-cdfa-94d3-7e04" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -3898,23 +3898,23 @@
               <entryLinks>
                 <entryLink id="2d27-3e98-ef2f-b37f" name="LMG" hidden="false" collective="false" import="true" targetId="6dc4-67a2-757e-5aa9" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5227-793a-865d-eca2" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04b1-a287-2384-cd5a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5227-793a-865d-eca2" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04b1-a287-2384-cd5a" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="14"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6930-4c47-7458-6493" name="Sniper Team" page="150" hidden="false" collective="false" import="true" type="unit">
@@ -3924,24 +3924,24 @@
         <infoLink id="386a-888f-cf7f-59db" name="2" hidden="false" targetId="b6c1-c83f-a555-17ce" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0416-d43c-a179-a0a1" name="New CategoryLink" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
+        <categoryLink id="0416-d43c-a179-a0a1" name="Infantry Support Squads" hidden="false" targetId="b7cf-ebf3-4ee6-2706" primary="true"/>
         <categoryLink id="ed72-0a65-8595-8e0b" name="Sniper Team" hidden="false" targetId="6077-3929-61c8-5eb7" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="f980-81b8-cb2a-f4d0" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="4555-a809-3ecd-06ff">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e54f-583a-ea8d-ec21" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98d1-72c7-489d-8e2b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e54f-583a-ea8d-ec21" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98d1-72c7-489d-8e2b" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="4555-a809-3ecd-06ff" name="Regular" hidden="false" collective="false" import="true" targetId="020b-0c80-419b-6391" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="52.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="52"/>
               </costs>
             </entryLink>
             <entryLink id="bc25-ccf9-a4b9-7f1c" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="67.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="67"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -3950,13 +3950,13 @@
       <entryLinks>
         <entryLink id="4bd0-c725-fa91-9fa1" name="Rifle" hidden="false" collective="false" import="true" targetId="69b8-002c-ef16-c6e4" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9979-77d8-e9a4-2649" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3b4-c9bc-055e-0f78" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9979-77d8-e9a4-2649" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3b4-c9bc-055e-0f78" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9b34-7997-136b-45b3" name="Tesla Anti-Tank Gun" hidden="false" collective="false" import="true" type="unit">
@@ -3971,56 +3971,56 @@
         <infoLink id="c5ea-6adf-0d43-9466" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="541d-3569-2356-3a08" name="New CategoryLink" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
+        <categoryLink id="541d-3569-2356-3a08" name="Artillery and Anti-tank Guns" hidden="false" targetId="5056-7005-6edc-4816" primary="true"/>
         <categoryLink id="2af3-f9e2-e222-1203" name="Anti-Tank Team" hidden="false" targetId="c04e-ff05-f7cb-ae9b" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="808a-4e39-3b7b-fe93" name="M17 Tesla Cannon" hidden="false" collective="false" import="true" targetId="5a0d-4460-5e5e-f5e7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="770d-d99f-3afb-d8d9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9816-b8ac-e15b-be2c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="770d-d99f-3afb-d8d9" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9816-b8ac-e15b-be2c" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="115.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="115"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bcda-3dae-042f-841d" name="Senior Officer" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="ae37-8809-fabb-7d90" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+            <condition field="selections" scope="ae37-8809-fabb-7d90" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="a73b-2dfe-58e8-3cc6" name="New CategoryLink" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
+        <categoryLink id="a73b-2dfe-58e8-3cc6" name="Headquarters" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
         <categoryLink id="822a-49a5-5aa4-3025" name="Senior Officer" hidden="false" targetId="b14d-60bd-51cb-1c49" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9987-a4f6-6d26-29bf" name="Additonal Men" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="671e-c195-7d45-ff48" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="671e-c195-7d45-ff48" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="96e7-17d2-e721-d14d" name="Soldier" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="7">
                       <conditions>
-                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
+                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -4029,8 +4029,8 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="8adc-1e93-98f9-d0b0" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="c2c9-0027-0004-e926">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ef6-3b36-a0c7-10b0" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99c2-6c56-8a59-a30d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ef6-3b36-a0c7-10b0" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99c2-6c56-8a59-a30d" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="ce7b-df39-53c0-034d" name="Pistol" hidden="false" collective="false" import="true" targetId="d7b1-e557-88f6-1ac4" type="selectionEntry"/>
@@ -4040,34 +4040,34 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="8381-e2db-d30b-e62a" name="Senior Officer" hidden="false" collective="false" import="true" defaultSelectionEntryId="a802-bf5a-6134-1bac">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4818-8cd4-7305-454a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aac4-5fa3-c0e1-6ad4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4818-8cd4-7305-454a" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aac4-5fa3-c0e1-6ad4" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="a766-45e9-802f-a203" name="Major" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="150.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="150">
                       <conditions>
-                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="135.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="135">
                       <conditions>
-                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
+                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="165.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="165">
                       <conditions>
-                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -4080,8 +4080,8 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="fb92-b7a1-bd02-b93c" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="1dfc-fad8-d06b-a093">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c5-9076-18fa-9e05" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94c3-fb4d-135d-e4ea" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c5-9076-18fa-9e05" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94c3-fb4d-135d-e4ea" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="6357-55c6-e836-81d0" name="Pistol" hidden="false" collective="false" import="true" targetId="d7b1-e557-88f6-1ac4" type="selectionEntry"/>
@@ -4091,26 +4091,26 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a802-bf5a-6134-1bac" name="Captain" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="110.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="110">
                       <conditions>
-                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="95.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="95">
                       <conditions>
-                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
+                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5344-848e-632f-9e09" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="125.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="125">
                       <conditions>
-                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="bcda-3dae-042f-841d" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -4123,8 +4123,8 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="5221-988d-7283-a284" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="7d60-1cd3-191d-fa51">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4bc-e111-048e-e354" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d817-8386-f5fe-0b53" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4bc-e111-048e-e354" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d817-8386-f5fe-0b53" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="e880-a328-e5a3-d92b" name="Pistol" hidden="false" collective="false" import="true" targetId="d7b1-e557-88f6-1ac4" type="selectionEntry"/>
@@ -4134,15 +4134,15 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="1fc2-85ae-fba2-4c62" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="1de8-6a43-8784-e2a9">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f50-5082-5d12-f6b0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00c8-f575-80db-7809" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f50-5082-5d12-f6b0" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00c8-f575-80db-7809" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="1de8-6a43-8784-e2a9" name="Inexperienced" hidden="false" collective="false" import="true" targetId="5344-848e-632f-9e09" type="selectionEntry"/>
@@ -4152,7 +4152,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="46b2-2167-a749-5b8c" name="M10 Tank Destroyer" page="157" hidden="false" collective="false" import="true" type="unit">
@@ -4161,11 +4161,11 @@
         <infoLink id="0524-e4c6-eec9-79ed" name="Open-Topped" hidden="false" targetId="29c0-1d9f-1f84-7795" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="bff2-48fe-87d8-8d88" name="New CategoryLink" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
-        <categoryLink id="dd75-6cf3-805c-9499" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="bff2-48fe-87d8-8d88" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
+        <categoryLink id="dd75-6cf3-805c-9499" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="2936-d0c1-d7f8-26d5" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="6dee-2aa4-1fdf-f753" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
-        <categoryLink id="b420-fe23-c592-dfae" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="b420-fe23-c592-dfae" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="eb3b-88a8-22bb-4480" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -4174,13 +4174,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="46b2-2167-a749-5b8c" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="46b2-2167-a749-5b8c" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4189,37 +4189,37 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ff4-8dc2-e466-bd2a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb62-83f2-5241-2099" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ff4-8dc2-e466-bd2a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb62-83f2-5241-2099" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="3415-ff32-6c8b-1c18" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="cd2f-a93f-b2c4-45dc" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="98cf-d7ec-7a7e-afdb">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cf4-5cd0-68ef-979d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f287-da75-f1c8-e764" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cf4-5cd0-68ef-979d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f287-da75-f1c8-e764" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="0d2c-a9b7-a966-f623" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="180.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="180"/>
               </costs>
             </entryLink>
             <entryLink id="6e38-1db8-2604-231c" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="216.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="216"/>
               </costs>
             </entryLink>
             <entryLink id="98cf-d7ec-7a7e-afdb" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="144.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="144"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -4228,30 +4228,30 @@
       <entryLinks>
         <entryLink id="b31f-ae99-b724-d447" name="Turret-Mounted Heavy AT Gun" hidden="false" collective="false" import="true" targetId="3296-6844-2b99-aa77" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e926-27c1-a72f-795f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a870-7913-ffdb-d9ff" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e926-27c1-a72f-795f" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a870-7913-ffdb-d9ff" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="09ba-9b4f-b548-8118" name="Pintle-Mounted Turret-Based HMG" hidden="false" collective="false" import="true" targetId="4d7a-e491-7f93-70d9" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b523-f239-a377-1f70" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b523-f239-a377-1f70" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
           </costs>
         </entryLink>
         <entryLink id="d947-5972-17c0-43a2" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cc58-65e7-8ad0-ad7b" name="M18 Hellcat" hidden="false" collective="false" import="true" type="unit">
@@ -4260,22 +4260,22 @@
         <infoLink id="aba5-dced-7cae-90cf" name="Open-Topped" hidden="false" targetId="29c0-1d9f-1f84-7795" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="bfcd-06ed-161e-3adc" name="New CategoryLink" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
-        <categoryLink id="b29e-e215-8af1-401e" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="bfcd-06ed-161e-3adc" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
+        <categoryLink id="b29e-e215-8af1-401e" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="9a34-9317-3808-bf79" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="2173-c4a8-fbaf-0caa" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
-        <categoryLink id="55d2-df1f-e876-1ccd" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="55d2-df1f-e876-1ccd" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2834-6f08-0536-c0ea" name="Recce" page="" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="2834-6f08-0536-c0ea" name="Recce" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5584-5c29-1e9e-c681" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5584-5c29-1e9e-c681" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="f6b7-a3a3-f6fb-ecda" name="Recce" hidden="false" targetId="fa0e-9e9d-0e65-1e3b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="af5f-6e53-88bc-73d4" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -4284,13 +4284,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc58-65e7-8ad0-ad7b" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc58-65e7-8ad0-ad7b" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4299,37 +4299,37 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c251-3346-1507-b89b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4de6-50a0-1438-2e86" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c251-3346-1507-b89b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4de6-50a0-1438-2e86" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="3d96-a6b1-6813-3d33" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="bd4b-5551-1a82-2daf" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="e196-b71c-a418-b149">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bd9-98e2-393d-e8a2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92fa-c91a-466c-599d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bd9-98e2-393d-e8a2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92fa-c91a-466c-599d" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="e196-b71c-a418-b149" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="132.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="132"/>
               </costs>
             </entryLink>
             <entryLink id="3b52-ad41-3337-d49e" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="197.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="197"/>
               </costs>
             </entryLink>
             <entryLink id="32d6-d28e-0ef9-7dca" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="165.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="165"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -4338,30 +4338,30 @@
       <entryLinks>
         <entryLink id="03f9-750d-c0c3-dcbc" name="Turret-Mounted Heavy AT Gun" hidden="false" collective="false" import="true" targetId="3296-6844-2b99-aa77" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b4e-dfa7-42dd-8611" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9a4-e854-7265-3701" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b4e-dfa7-42dd-8611" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9a4-e854-7265-3701" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="9d37-da0e-3062-1e81" name="Pintle-Mounted Turret-Based HMG" hidden="false" collective="false" import="true" targetId="4d7a-e491-7f93-70d9" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccdd-bde1-f085-ff4f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccdd-bde1-f085-ff4f" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
           </costs>
         </entryLink>
         <entryLink id="5cdb-0b12-7175-a3a6" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bba7-52e2-b1bd-51da" name="M36 Jackson" hidden="false" collective="false" import="true" type="unit">
@@ -4370,11 +4370,11 @@
         <infoLink id="64d5-f300-9c9b-957f" name="Open-Topped" hidden="false" targetId="29c0-1d9f-1f84-7795" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b979-0ebe-87f5-58de" name="New CategoryLink" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
-        <categoryLink id="4d19-eb29-545f-d50a" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="b979-0ebe-87f5-58de" name="Tanks and Tank Destroyers" hidden="false" targetId="8847-c5b7-a651-1556" primary="true"/>
+        <categoryLink id="4d19-eb29-545f-d50a" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="7bb8-d16b-176f-242c" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="2849-5508-76bd-4a2e" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
-        <categoryLink id="39d1-3f7d-2a64-6550" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="39d1-3f7d-2a64-6550" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="2b46-cfab-5a8f-1f75" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -4383,13 +4383,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bba7-52e2-b1bd-51da" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bba7-52e2-b1bd-51da" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4398,37 +4398,37 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a0d-0d60-7521-ef92" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c440-444f-a2ef-3e21" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a0d-0d60-7521-ef92" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c440-444f-a2ef-3e21" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="e0a0-7996-f51d-70a1" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="1601-bd9a-d044-fe42" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="fe2c-3fc5-6860-86df">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0736-c4cc-704a-7a78" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e61-9bda-cb8b-3e3c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0736-c4cc-704a-7a78" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e61-9bda-cb8b-3e3c" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="3abd-34d7-7784-13f7" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="255.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="255"/>
               </costs>
             </entryLink>
             <entryLink id="79ec-cee6-1a6a-62f0" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="306.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="306"/>
               </costs>
             </entryLink>
             <entryLink id="fe2c-3fc5-6860-86df" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="204.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="204"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -4437,30 +4437,30 @@
       <entryLinks>
         <entryLink id="dafe-0431-4152-7da9" name="Turret-Mounted Super-Heavy AT Gun" publicationId="9a47-ac76-pubN65784" page="157" hidden="false" collective="false" import="true" targetId="359d-ffaf-84b8-7008" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86c4-6611-9081-27fd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffad-de0a-efe4-8eda" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86c4-6611-9081-27fd" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffad-de0a-efe4-8eda" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="e81b-3c18-3a90-ae4a" name="Pintle-Mounted Turret-Based HMG" hidden="false" collective="false" import="true" targetId="4d7a-e491-7f93-70d9" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4133-3fb0-c7e6-e547" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4133-3fb0-c7e6-e547" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
           </costs>
         </entryLink>
         <entryLink id="1f63-5056-ebfa-5ba5" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8d22-d61a-2988-b00a" name="M5A2 Coyote Light Walker" hidden="false" collective="false" import="true" type="unit">
@@ -4473,7 +4473,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="e273-b88c-3958-4417" name="Scout and Light Walkers" hidden="false" targetId="81cb-605d-a02f-88ca" primary="false"/>
-        <categoryLink id="b112-a362-5836-62a0" name="New CategoryLink" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
+        <categoryLink id="b112-a362-5836-62a0" name="Walkers" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
         <categoryLink id="033f-a410-8654-7ae5" name="Armored Cars, Scout and Light Walkers" hidden="false" targetId="00b4-e9d7-e705-1f53" primary="false"/>
         <categoryLink id="69ca-0328-35fc-b305" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
         <categoryLink id="c357-3553-1010-98ab" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
@@ -4487,13 +4487,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d22-d61a-2988-b00a" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d22-d61a-2988-b00a" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4502,32 +4502,32 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9012-9d8c-9f84-3806" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cbd1-22fd-c1f5-1af0" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9012-9d8c-9f84-3806" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cbd1-22fd-c1f5-1af0" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="da39-cea6-36e3-6b80" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="6e39-30c3-42b1-d835" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="c8bd-1aa3-5854-4704">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c90b-ec8d-e984-c3b0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f0c-bd7a-92dd-755d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c90b-ec8d-e984-c3b0" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f0c-bd7a-92dd-755d" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="672e-cf18-3e99-f8be" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="110.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="110"/>
               </costs>
             </entryLink>
             <entryLink id="c8bd-1aa3-5854-4704" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="90.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="90"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -4536,34 +4536,34 @@
       <entryLinks>
         <entryLink id="3fdc-4c5e-ad98-e300" name="Right Arm-Mounted MMG" hidden="false" collective="false" import="true" targetId="c676-8ab1-132f-38e5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6639-8da5-0723-a480" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f36-7762-60f1-6da3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6639-8da5-0723-a480" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f36-7762-60f1-6da3" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="e4d5-b53a-402e-1571" name="Fist" hidden="false" collective="true" import="true" targetId="8503-f9cf-c544-aa05" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb6f-195a-62f7-9977" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="583d-ea8f-e65d-96e4" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb6f-195a-62f7-9977" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="583d-ea8f-e65d-96e4" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="0c24-4019-757e-0eb8" name="Casement-Mounted Forward-Facing HMG" hidden="false" collective="false" import="true" targetId="44b5-3b8d-226f-adb1" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6039-9de8-65b2-1002" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4470-f466-2958-f42a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6039-9de8-65b2-1002" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4470-f466-2958-f42a" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="8cf2-e9c8-d7e4-8676" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5ef7-c24a-72ae-9cbe" name="M5A5/6 Jackal Light Walker" hidden="false" collective="false" import="true" type="unit">
@@ -4577,7 +4577,7 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1e37-3f8a-8f6c-2737" name="Scout and Light Walkers" hidden="false" targetId="81cb-605d-a02f-88ca" primary="false"/>
-        <categoryLink id="b778-6ef4-8cae-dd49" name="New CategoryLink" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
+        <categoryLink id="b778-6ef4-8cae-dd49" name="Walkers" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
         <categoryLink id="831e-9e9e-8830-2319" name="Armored Cars, Scout and Light Walkers" hidden="false" targetId="00b4-e9d7-e705-1f53" primary="false"/>
         <categoryLink id="cd27-e706-04fa-2e2f" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="8c84-2b80-026d-37a2" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
@@ -4591,13 +4591,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ef7-c24a-72ae-9cbe" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ef7-c24a-72ae-9cbe" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4606,32 +4606,32 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c81d-f48f-d5f3-7833" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b5e-3232-1c35-3299" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c81d-f48f-d5f3-7833" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b5e-3232-1c35-3299" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="d389-03a5-9532-afa9" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="4e64-c20b-0a1f-0dd1" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="3596-9b85-9a1c-df9d">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d882-6a5c-99d2-b392" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5058-8b13-8445-aaf8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d882-6a5c-99d2-b392" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5058-8b13-8445-aaf8" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="c993-bfed-1352-b569" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="105.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="105"/>
               </costs>
             </entryLink>
             <entryLink id="3596-9b85-9a1c-df9d" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="90.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="90"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -4640,36 +4640,36 @@
       <entryLinks>
         <entryLink id="4357-de15-da44-126c" name="Right Arm-Mounted MMG" hidden="false" collective="false" import="true" targetId="c676-8ab1-132f-38e5" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce24-a6e1-cd5a-129f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5fd-af2d-5deb-baf8" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce24-a6e1-cd5a-129f" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5fd-af2d-5deb-baf8" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="96c0-5d4c-29fc-aa89" name="Fist" hidden="false" collective="true" import="true" targetId="8503-f9cf-c544-aa05" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1fc-4601-8181-a11a" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d13-b98b-6385-95fd" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1fc-4601-8181-a11a" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d13-b98b-6385-95fd" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="568e-4547-dafc-fced" name="Left Arm-Mounted Flamethrower (Infantry)" hidden="false" collective="false" import="true" targetId="6f91-f2da-b621-a64d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13b4-b258-a1b8-20c1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13b4-b258-a1b8-20c1" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20"/>
           </costs>
         </entryLink>
         <entryLink id="d729-807e-91b9-f7d3" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2afb-dafc-cb1f-1056" name="M8 Grizzly Medium Assault Walker" hidden="false" collective="false" import="true" type="unit">
@@ -4679,11 +4679,11 @@
         <infoLink id="e308-6559-d33a-6947" name="Assault (Vehicle)" hidden="false" targetId="7e17-fe3a-569d-ccc5" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="3423-0cc7-7939-3fcf" name="New CategoryLink" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
-        <categoryLink id="c2bd-cab1-b69d-fc60" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="3423-0cc7-7939-3fcf" name="Walkers" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
+        <categoryLink id="c2bd-cab1-b69d-fc60" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
         <categoryLink id="369e-bb0e-c5af-4bcd" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
         <categoryLink id="ab23-7279-063b-15be" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
-        <categoryLink id="700f-8c74-90ba-b680" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="700f-8c74-90ba-b680" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6f70-a08f-710e-a6eb" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -4692,13 +4692,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2afb-dafc-cb1f-1056" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2afb-dafc-cb1f-1056" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4707,32 +4707,32 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b73e-3263-87be-3177" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa3a-03c3-cbb1-36e8" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b73e-3263-87be-3177" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa3a-03c3-cbb1-36e8" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="591e-9a01-5e40-3e53" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="05b8-e987-0a27-b89b" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="d14c-a69b-0764-131e">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a1a-e0e4-f5a8-35dd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aab6-3075-70ca-4da5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a1a-e0e4-f5a8-35dd" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aab6-3075-70ca-4da5" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="3f21-abfa-1859-7f1c" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="245.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="245"/>
               </costs>
             </entryLink>
             <entryLink id="d14c-a69b-0764-131e" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="200.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="200"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -4741,8 +4741,8 @@
       <entryLinks>
         <entryLink id="d1a2-910d-8f95-37fc" name="Casement-Mounted Forward-Facing Medium AT Gun" hidden="false" collective="false" import="true" targetId="e72a-1e34-fcfe-db78" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c1-11ca-1ebe-043d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83f3-087a-d79c-a646" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c1-11ca-1ebe-043d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83f3-087a-d79c-a646" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="ec0c-a21b-bddf-7cbb" name="75mm HE" hidden="false" targetId="0315-8062-b1dd-4c5d" type="rule"/>
@@ -4751,28 +4751,28 @@
         </entryLink>
         <entryLink id="e58a-e3e0-1c7e-11f6" name="Fist" hidden="false" collective="true" import="true" targetId="8503-f9cf-c544-aa05" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ac0-f185-fe1d-4a93" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3673-16bb-441d-c823" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ac0-f185-fe1d-4a93" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3673-16bb-441d-c823" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="cee3-4ad1-3dd2-cc9c" name="Pintle-Mounted Forward-Facing HMG" hidden="false" collective="false" import="true" targetId="0fde-b247-5ea6-a771" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d520-4bbc-fdd5-cd04" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fdf-888e-e9fd-eeb4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d520-4bbc-fdd5-cd04" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fdf-888e-e9fd-eeb4" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="4c12-6d07-419c-b4c4" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1aaf-09b1-230f-3dea" name="M8A4 Bruin Support Walker" hidden="false" collective="false" import="true" type="unit">
@@ -4789,9 +4789,9 @@
         <infoLink id="5a14-5c81-6fd7-5e67" name="Walker" hidden="false" targetId="cc4e-54c3-faab-0936" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8865-57fd-adb5-93d8" name="New CategoryLink" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
-        <categoryLink id="dc7c-584b-ef34-72e6" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
-        <categoryLink id="b709-5be5-7a91-f45b" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="8865-57fd-adb5-93d8" name="Walkers" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
+        <categoryLink id="dc7c-584b-ef34-72e6" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="b709-5be5-7a91-f45b" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="b68e-1260-c758-d647" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="614e-a8ea-21bb-ee57" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
       </categoryLinks>
@@ -4802,13 +4802,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1aaf-09b1-230f-3dea" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1aaf-09b1-230f-3dea" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4817,32 +4817,32 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0f0a-3539-074d-a0bd" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6fc0-970a-a251-cd40" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0f0a-3539-074d-a0bd" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6fc0-970a-a251-cd40" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="784f-2dd6-e1a1-858b" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="69bc-64c5-f234-9495" name="Quality" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3142-501f-e95d-5e97" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a48-a611-93a2-a52f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3142-501f-e95d-5e97" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a48-a611-93a2-a52f" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="5c4b-cae8-d9ba-b383" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="285.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="285"/>
               </costs>
             </entryLink>
             <entryLink id="941c-1653-8247-cdf7" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="220.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="220"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -4851,14 +4851,14 @@
       <entryLinks>
         <entryLink id="a985-26af-da60-e458" name="Arm Mounted Heavy Howitzer" hidden="false" collective="false" import="true" targetId="f0b0-d4cd-1eab-b30e" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5b3-1f6a-1cde-911f" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a480-fc42-6672-9bc6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5b3-1f6a-1cde-911f" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a480-fc42-6672-9bc6" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="2a4f-d248-1e31-1562" name="Casement-Mounted Forward-Facing Medium AT Gun" hidden="false" collective="true" import="true" targetId="e72a-1e34-fcfe-db78" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="207c-f40c-5cc0-6712" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b741-78be-f65a-ecb1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="207c-f40c-5cc0-6712" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b741-78be-f65a-ecb1" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="6930-a132-e8dd-53cf" name="Gyro-Stabilised" hidden="false" targetId="17c2-1379-b790-b8be" type="rule"/>
@@ -4866,22 +4866,22 @@
         </entryLink>
         <entryLink id="3de4-6f70-c97d-920b" name="Pintle-Mounted Forward-Facing HMG" hidden="false" collective="false" import="true" targetId="0fde-b247-5ea6-a771" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3649-6a05-b38b-8e7b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb56-24ac-ed6a-136d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3649-6a05-b38b-8e7b" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb56-24ac-ed6a-136d" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="0303-bdad-3a09-8f2a" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5ad6-7978-8ed1-3808" name="M9A2 Kodiak Close Assault Walker" hidden="false" collective="false" import="true" type="unit">
@@ -4891,11 +4891,11 @@
         <infoLink id="35af-7290-ce22-55d4" name="Flak" hidden="false" targetId="2257-21e2-e6a0-367d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b345-a7a3-04cd-c296" name="New CategoryLink" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
-        <categoryLink id="1b9d-b2dd-c349-66f8" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="b345-a7a3-04cd-c296" name="Walkers" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
+        <categoryLink id="1b9d-b2dd-c349-66f8" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
         <categoryLink id="42c5-fcd0-029f-b2a6" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
         <categoryLink id="194d-3916-ab60-92f8" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
-        <categoryLink id="7ea8-ee5f-4379-dfad" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="7ea8-ee5f-4379-dfad" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="360d-4760-d0a1-1153" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -4904,13 +4904,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ad6-7978-8ed1-3808" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ad6-7978-8ed1-3808" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -4919,32 +4919,32 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2143-22cb-2647-a13f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff27-ccfd-9f24-f768" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2143-22cb-2647-a13f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff27-ccfd-9f24-f768" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="5e2b-fba8-744e-6371" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="00ed-93f5-9e05-903c" name="Quality" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d570-bd9e-30cf-1418" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17b0-74ee-818f-58d1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d570-bd9e-30cf-1418" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17b0-74ee-818f-58d1" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="d6fa-27e9-93e2-25ff" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="260.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="260"/>
               </costs>
             </entryLink>
             <entryLink id="0c41-b65c-b8c2-b6cd" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="210.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="210"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -4953,40 +4953,40 @@
       <entryLinks>
         <entryLink id="7ff2-92eb-5c77-06a4" name="Left Arm-Mounted Light Automatic Cannon" hidden="false" collective="false" import="true" targetId="598c-2215-8227-7b54" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab3a-2a17-0821-3561" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ed1-23e0-c166-6e97" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab3a-2a17-0821-3561" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ed1-23e0-c166-6e97" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="54dc-6fe7-b69c-6f0e" name="Right Arm-Mounted Light Automatic Cannon" hidden="false" collective="false" import="true" targetId="bcff-5e9c-3c71-6776" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbb0-0f73-fe61-b302" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a22c-f347-a915-5f74" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbb0-0f73-fe61-b302" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a22c-f347-a915-5f74" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="84e0-7131-6145-f842" name="Right Arm-Mounted HMG" hidden="false" collective="false" import="true" targetId="120c-e493-2f7b-a6fb" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21f7-253a-80b0-948f" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6dc-d368-cc57-7925" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21f7-253a-80b0-948f" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6dc-d368-cc57-7925" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="35bf-26d9-3780-cb77" name="Left Arm-Mounted HMG" hidden="false" collective="false" import="true" targetId="95a3-ebc8-a68d-5f1d" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fa1-12da-5b50-4aee" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bca8-8ff2-c33b-f907" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fa1-12da-5b50-4aee" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bca8-8ff2-c33b-f907" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="5b1a-073f-1ae1-73da" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d43c-bc0a-5f52-fd42" name="M2 Mudskipper Jump Walker" publicationId="9a47-ac76-pubN66291" page="45" hidden="false" collective="false" import="true" type="unit">
@@ -4998,11 +4998,11 @@
         <infoLink id="bbf2-7275-b672-68e0" name="Veteran (Vehicle)" hidden="false" targetId="87de-25e7-d35e-25a7" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="f7d0-4a6c-3520-1e34" name="New CategoryLink" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
-        <categoryLink id="fde6-7e28-7777-8fb9" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="f7d0-4a6c-3520-1e34" name="Walkers" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
+        <categoryLink id="fde6-7e28-7777-8fb9" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
         <categoryLink id="1851-0519-a098-5e59" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
         <categoryLink id="02c7-0ae4-ba73-0315" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
-        <categoryLink id="8b70-76a5-60c6-3277" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="8b70-76a5-60c6-3277" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="102d-fdc5-4286-e474" name="Radio Network" hidden="true" collective="false" import="true" type="upgrade">
@@ -5011,13 +5011,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d43c-bc0a-5f52-fd42" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d43c-bc0a-5f52-fd42" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -5026,56 +5026,56 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f4e0-c92a-4cac-eb9a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e080-00d2-bd8d-f0da" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f4e0-c92a-4cac-eb9a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e080-00d2-bd8d-f0da" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="cb12-52e8-fe7a-b13a" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="9ae4-f662-4d32-9197" name="Left Arm" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f62e-2b0d-be2c-fd58" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7169-4b90-137c-cb68" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f62e-2b0d-be2c-fd58" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7169-4b90-137c-cb68" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="f772-1866-286b-f07e" name="Left Arm-Mounted Bazooka" hidden="false" collective="false" import="true" targetId="ecac-f513-6105-dac1" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0fc-4f5a-2ba6-208d" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0fc-4f5a-2ba6-208d" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10"/>
               </costs>
             </entryLink>
             <entryLink id="35b6-bfaa-11ac-f2df" name="Left Arm-Mounted HMG" hidden="false" collective="false" import="true" targetId="95a3-ebc8-a68d-5f1d" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca0c-e767-8ab6-5da9" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca0c-e767-8ab6-5da9" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="6f4d-868b-e3ed-ae2a" name="Right Arm" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92d9-80d2-3dde-ab22" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04e8-65ea-bc0e-08b1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92d9-80d2-3dde-ab22" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04e8-65ea-bc0e-08b1" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="4d14-31bb-5881-b2c5" name="Right Arm-Mounted Bazooka" hidden="false" collective="false" import="true" targetId="0562-0a56-8841-c1ed" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e50-fb6d-955c-4cf3" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e50-fb6d-955c-4cf3" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10"/>
               </costs>
             </entryLink>
             <entryLink id="9f1d-51fe-8385-2a86" name="Right Arm-Mounted HMG" hidden="false" collective="false" import="true" targetId="120c-e493-2f7b-a6fb" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d69-b131-04bf-2edf" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d69-b131-04bf-2edf" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -5084,8 +5084,8 @@
       <entryLinks>
         <entryLink id="aed1-81bc-d260-1ca1" name="Casement-Mounted Forward-Facing Light Automatic Cannon" hidden="false" collective="false" import="true" targetId="6854-ac6c-9320-f2c2" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae98-97d2-56c9-7054" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e93-bfda-1308-2919" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae98-97d2-56c9-7054" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e93-bfda-1308-2919" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="d24b-2152-f072-4312" name="Linked Weapon" hidden="false" targetId="ee9e-cbe2-d442-9e46" type="rule"/>
@@ -5093,28 +5093,34 @@
         </entryLink>
         <entryLink id="2cc0-f51d-32e4-b376" name="Fist" hidden="false" collective="true" import="true" targetId="8503-f9cf-c544-aa05" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d46-21ed-9d0d-80e6" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8f9-31d6-69e3-dadd" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d46-21ed-9d0d-80e6" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8f9-31d6-69e3-dadd" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="e9d0-b869-31aa-e368" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
+        <entryLink import="true" name="Casement-Mounted Forward-Facing MMG" hidden="false" id="8512-28ad-acc2-ca57" type="selectionEntry" targetId="0db8-6972-ca9f-f49e">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f6e6-cdfd-e73f-7f7c-min" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f6e6-cdfd-e73f-7f7c-max" includeChildSelections="false"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="240.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="240"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3f5d-e00d-362a-0a06" name="M3A2 Pondskater Scout Walker" publicationId="9a47-ac76-pubN66291" page="45" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="efde-2c11-6361-414f" name="Scout and Light Walkers" hidden="false" targetId="81cb-605d-a02f-88ca" primary="false"/>
-        <categoryLink id="e9e6-a517-d5e4-58c4" name="New CategoryLink" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
+        <categoryLink id="e9e6-a517-d5e4-58c4" name="Walkers" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
         <categoryLink id="4deb-e974-b9a1-0e71" name="Armored Cars, Scout and Light Walkers" hidden="false" targetId="00b4-e9d7-e705-1f53" primary="false"/>
         <categoryLink id="eb25-41cb-81b3-30cb" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="8f1c-9846-b6cf-be3a" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
@@ -5124,8 +5130,8 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="cc45-f242-e61d-92e4" name="Walkers" hidden="false" collective="false" import="true" defaultSelectionEntryId="529f-6d3e-9e11-299e">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6524-0e55-304e-cf5a" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14c3-ceb3-2aa9-bdd2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6524-0e55-304e-cf5a" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14c3-ceb3-2aa9-bdd2" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="529f-6d3e-9e11-299e" name="M3A2 Pondskater Scout Walker" hidden="false" collective="false" import="true" type="unit">
@@ -5140,8 +5146,8 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="529f-6d3e-9e11-299e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8631-bede-ed91-ff75" type="greaterThan"/>
-                            <condition field="selections" scope="529f-6d3e-9e11-299e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4a1-baaf-b548-358c" type="greaterThan"/>
+                            <condition field="selections" scope="529f-6d3e-9e11-299e" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8631-bede-ed91-ff75" type="greaterThan"/>
+                            <condition field="selections" scope="529f-6d3e-9e11-299e" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4a1-baaf-b548-358c" type="greaterThan"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -5156,13 +5162,13 @@
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="529f-6d3e-9e11-299e" type="atLeast"/>
+                            <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="529f-6d3e-9e11-299e" type="atLeast"/>
                           </conditions>
                           <conditionGroups>
                             <conditionGroup type="or">
                               <conditions>
-                                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                               </conditions>
                             </conditionGroup>
                           </conditionGroups>
@@ -5171,68 +5177,68 @@
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="50d7-9d58-910c-2952" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5641-1c25-7edf-fa34" type="max"/>
+                    <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="50d7-9d58-910c-2952" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5641-1c25-7edf-fa34" type="max"/>
                   </constraints>
                   <infoLinks>
                     <infoLink id="d735-917f-c7ac-b933" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
                   </infoLinks>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups>
                 <selectionEntryGroup id="22fb-7c37-98a4-66a7" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="d4f0-b94b-bcee-2579">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc92-3342-ed37-6f03" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9574-ece4-5e3d-aaf9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc92-3342-ed37-6f03" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9574-ece4-5e3d-aaf9" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="d4f0-b94b-bcee-2579" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="75.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="75"/>
                       </costs>
                     </entryLink>
                     <entryLink id="6d59-b473-ddde-d1e3" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="95.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="95"/>
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="366a-14ee-75ea-beee" name="Loadout" hidden="false" collective="false" import="true" defaultSelectionEntryId="3836-c553-ccc7-2a01">
                   <modifiers>
-                    <modifier type="decrement" field="0206-1c8b-4742-6898" value="1.0">
+                    <modifier type="decrement" field="0206-1c8b-4742-6898" value="1">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4a1-baaf-b548-358c" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4a1-baaf-b548-358c" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b49f-f409-9bae-f9bf" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0206-1c8b-4742-6898" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b49f-f409-9bae-f9bf" type="min"/>
+                    <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0206-1c8b-4742-6898" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="fa52-ef8d-6677-bfb2" name="Casement-Mounted Forward-Facing Light AT Gun" hidden="false" collective="false" import="true" targetId="8631-bede-ed91-ff75" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbc5-dbd5-44f1-ee3f" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbc5-dbd5-44f1-ee3f" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="30.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="30"/>
                       </costs>
                     </entryLink>
                     <entryLink id="3836-c553-ccc7-2a01" name="360-Degree Pintle-Mounted HMG" hidden="false" collective="false" import="true" targetId="313c-cc03-e580-126f" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="614a-b56d-ba7e-f976" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="614a-b56d-ba7e-f976" type="max"/>
                       </constraints>
                     </entryLink>
                     <entryLink id="fc33-4b07-3c4c-9a46" name="360-Degree Pintle-Mounted Dual HMG" hidden="false" collective="false" import="true" targetId="b4a1-baaf-b548-358c" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cd7-0cf3-bc89-fdbd" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cd7-0cf3-bc89-fdbd" type="max"/>
                       </constraints>
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
                       </costs>
                     </entryLink>
                   </entryLinks>
@@ -5241,36 +5247,36 @@
               <entryLinks>
                 <entryLink id="6583-f2d1-7351-0f00" name="Casement-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="0db8-6972-ca9f-f49e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7423-8b70-6868-84c5" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d5f-b020-8cf8-c0b7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7423-8b70-6868-84c5" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d5f-b020-8cf8-c0b7" type="max"/>
                   </constraints>
                 </entryLink>
                 <entryLink id="e275-1cc8-87e8-122d" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditions>
-                        <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                        <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="20c5-c704-c645-e827" name="M7 Priest" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+            <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -5280,30 +5286,30 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="201b-5533-563f-be1b" name="Assault Guns and Self-Propelled Artillery" hidden="false" targetId="ae27-9d73-1390-d87c" primary="true"/>
-        <categoryLink id="2961-c636-4a40-e156" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="2961-c636-4a40-e156" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="3a49-b5f6-5d49-84a1" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="4d42-07ea-47bc-53b4" name="AA Vehicle and Self-Propelled Artillery" hidden="false" targetId="4bd2-90aa-426c-2737" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="5242-2d59-424b-ce27" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="aa39-1fbb-5e56-cd20">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6be-aaac-53fc-3bb9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de40-1f4d-56cf-7a86" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6be-aaac-53fc-3bb9" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de40-1f4d-56cf-7a86" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="aa39-1fbb-5e56-cd20" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="128.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="128"/>
               </costs>
             </entryLink>
             <entryLink id="55d9-b3d2-a479-b5e9" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="192.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="192"/>
               </costs>
             </entryLink>
             <entryLink id="7bfc-060a-31e7-2712" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="160.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="160"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -5312,26 +5318,26 @@
       <entryLinks>
         <entryLink id="193e-fb1c-fa4f-2f5c" name="360-Degree Pintle-Mounted HMG" hidden="false" collective="false" import="true" targetId="313c-cc03-e580-126f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a10a-15f7-3063-8eaf" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebb8-8bd4-aba4-1e91" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a10a-15f7-3063-8eaf" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebb8-8bd4-aba4-1e91" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="d5ef-8ec4-b1db-8620" name="Hull-Mounted Forward-Facing Medium Howitzer" hidden="false" collective="false" import="true" targetId="1f99-c9be-c7cc-7591" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b30c-120b-347f-1e08" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ac5-493e-c920-8101" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b30c-120b-347f-1e08" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ac5-493e-c920-8101" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2395-7beb-fcf2-3280" name="M12 Gun Motor Carriage" page="159" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+            <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -5340,31 +5346,31 @@
         <infoLink id="3dd0-bdcc-17c9-6632" name="Open-Topped" hidden="false" targetId="29c0-1d9f-1f84-7795" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e377-af8b-493e-00d0" name="New CategoryLink" hidden="false" targetId="4bd2-90aa-426c-2737" primary="false"/>
+        <categoryLink id="e377-af8b-493e-00d0" name="AA Vehicle and Self-Propelled Artillery" hidden="false" targetId="4bd2-90aa-426c-2737" primary="false"/>
         <categoryLink id="1804-4865-e4fa-0cbe" name="Assault Guns and Self-Propelled Artillery" hidden="false" targetId="ae27-9d73-1390-d87c" primary="true"/>
-        <categoryLink id="bf91-6f74-0534-9071" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="bf91-6f74-0534-9071" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="819a-3364-285e-d4a9" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="a163-f860-9dd5-f381" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="94c9-f4a6-447d-a5f1">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fccf-7b5f-1d8b-1b02" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8d5-6c54-b66b-df13" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fccf-7b5f-1d8b-1b02" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8d5-6c54-b66b-df13" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="94c9-f4a6-447d-a5f1" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="140.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="140"/>
               </costs>
             </entryLink>
             <entryLink id="9ee9-9438-b8f4-a2a5" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="210.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="210"/>
               </costs>
             </entryLink>
             <entryLink id="04a2-f5ad-7cde-89a8" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="175.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="175"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -5373,26 +5379,26 @@
       <entryLinks>
         <entryLink id="03f7-71b2-2c24-ee5c" name="360-Degree Pintle-Mounted HMG" hidden="false" collective="false" import="true" targetId="313c-cc03-e580-126f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0791-5251-25e0-3ceb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21d3-4989-aaf4-f09a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0791-5251-25e0-3ceb" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21d3-4989-aaf4-f09a" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="2b81-c94f-98ac-5cf1" name="Hull-Mounted Forward-Facing Heavy Howitzer" hidden="false" collective="false" import="true" targetId="b631-611b-1d02-5991" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f02-1212-c142-1b49" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16c4-3688-91e1-8566" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f02-1212-c142-1b49" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16c4-3688-91e1-8566" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2e33-eaca-31aa-2e75" name="M21 Mortar Carriage" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+            <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -5401,31 +5407,31 @@
         <infoLink id="e1ac-8a5c-ba4e-48da" name="Open-Topped" hidden="false" targetId="29c0-1d9f-1f84-7795" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7ad2-6525-48e2-6e71" name="New CategoryLink" hidden="false" targetId="4bd2-90aa-426c-2737" primary="false"/>
+        <categoryLink id="7ad2-6525-48e2-6e71" name="AA Vehicle and Self-Propelled Artillery" hidden="false" targetId="4bd2-90aa-426c-2737" primary="false"/>
         <categoryLink id="1819-7ddd-fb94-1756" name="Assault Guns and Self-Propelled Artillery" hidden="false" targetId="ae27-9d73-1390-d87c" primary="true"/>
-        <categoryLink id="6a46-6d32-4c14-e649" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="6a46-6d32-4c14-e649" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="577e-aae3-afe2-5e95" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="c038-83ac-8aed-a378" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="e7cc-ffc6-d174-00fc">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb5b-ea43-e702-1a21" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d522-0ff1-5bf2-895f" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb5b-ea43-e702-1a21" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d522-0ff1-5bf2-895f" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="e7cc-ffc6-d174-00fc" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="76.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="76"/>
               </costs>
             </entryLink>
             <entryLink id="a619-f287-f466-1d21" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="114.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="114"/>
               </costs>
             </entryLink>
             <entryLink id="f6e9-3c20-778b-3ec5" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="95.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="95"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -5434,26 +5440,26 @@
       <entryLinks>
         <entryLink id="7e35-d4ff-9c80-07fe" name="360-Degree Pintle-Mounted HMG" hidden="false" collective="false" import="true" targetId="313c-cc03-e580-126f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c17f-3e46-4a51-04be" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e25-7d8e-f051-c30e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c17f-3e46-4a51-04be" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e25-7d8e-f051-c30e" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="bc4d-3394-860f-5c03" name="Hull-Mounted Forward-Facing Medium Mortar" hidden="false" collective="false" import="true" targetId="8aad-9827-72d2-822f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="007c-1f7d-1e5b-f648" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dbb-f0b8-d783-5e17" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="007c-1f7d-1e5b-f648" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dbb-f0b8-d783-5e17" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3cf3-d80e-1023-1a32" name="M16 Anti-Aircraft Carriage" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+            <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -5463,92 +5469,92 @@
         <infoLink id="946f-a3ad-8d72-fe9e" name="Flak" hidden="false" targetId="2257-21e2-e6a0-367d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="bd18-671c-7b5a-2cc4" name="New CategoryLink" hidden="false" targetId="4bd2-90aa-426c-2737" primary="false"/>
-        <categoryLink id="62e4-9f99-9a57-919a" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="bd18-671c-7b5a-2cc4" name="AA Vehicle and Self-Propelled Artillery" hidden="false" targetId="4bd2-90aa-426c-2737" primary="false"/>
+        <categoryLink id="62e4-9f99-9a57-919a" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
         <categoryLink id="4f6e-ecc9-1292-91b1" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
         <categoryLink id="5794-2729-ffed-8c6b" name="Armoured Cars and Anti-Aircraft Vehicles" hidden="false" targetId="5c3c-21b9-e716-a67e" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="4045-744e-9a5f-6fea" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="1ed4-4170-706f-f0df">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3c3-4b7f-7109-ada5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7020-450e-b160-5d83" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3c3-4b7f-7109-ada5" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7020-450e-b160-5d83" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="1ed4-4170-706f-f0df" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="100.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="100"/>
               </costs>
             </entryLink>
             <entryLink id="c459-3506-1078-99b7" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="150.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="150"/>
               </costs>
             </entryLink>
             <entryLink id="2842-db6d-8e0b-51c8" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="125.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="125"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="e3c5-d9a4-a2ff-5b6a" name="Turret Weapon" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cb1-48a0-9531-19f6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a15-55ee-2c66-9eee" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cb1-48a0-9531-19f6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a15-55ee-2c66-9eee" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="093e-9786-8c3e-3753" name="Quad HMGs" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a58-ddb0-98e9-194d" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a58-ddb0-98e9-194d" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="b651-38cd-252a-ce46" name="Turret-Mounted HMG" hidden="false" collective="false" import="true" targetId="e21f-3661-f05b-8a03" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bec-cd39-4edd-2f02" type="min"/>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cba6-8c03-75a6-a3bf" type="max"/>
+                    <constraint field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bec-cd39-4edd-2f02" type="min"/>
+                    <constraint field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cba6-8c03-75a6-a3bf" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="56f4-2b2f-6288-bae1" name="Heavy Automatic Cannon" hidden="false" collective="false" import="true" targetId="beb9-f6f1-ca97-4bcf" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df80-0831-d292-1d62" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df80-0831-d292-1d62" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="-50.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="-50"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="bb89-042c-acef-64be" name="Pintle Mount" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e18-4b86-a64c-1cc2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e18-4b86-a64c-1cc2" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="1bcf-a739-2c49-9218" name="Pintle-Mounted Rear-Facing MMG" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
                 <entryLink id="2ff0-5a4e-bb3b-2bd9" name="MMG" hidden="false" collective="false" import="true" targetId="ff34-acf0-0405-2cfb" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1a5-7c6c-ef6e-6ed7" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a659-6887-3ee7-8ea3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1a5-7c6c-ef6e-6ed7" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a659-6887-3ee7-8ea3" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3351-24d6-e7b2-d734" name="M8 Greyhound Armoured Car" hidden="false" collective="false" import="true" type="unit">
@@ -5571,13 +5577,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3351-24d6-e7b2-d734" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3351-24d6-e7b2-d734" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -5586,37 +5592,37 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="27ae-8e3b-c0ff-9626" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="28f3-c660-8546-d0de" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="27ae-8e3b-c0ff-9626" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="28f3-c660-8546-d0de" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="fb93-7e91-e283-610f" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="114c-6205-8580-440d" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="3068-48d8-ca0e-4143">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f623-2bb8-c827-28f7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a190-5104-5067-b0e9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f623-2bb8-c827-28f7" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a190-5104-5067-b0e9" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="3068-48d8-ca0e-4143" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="88.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="88"/>
               </costs>
             </entryLink>
             <entryLink id="1b2f-9e66-d60a-42da" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="132.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="132"/>
               </costs>
             </entryLink>
             <entryLink id="73cc-d3c5-1089-b9e9" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="110.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="110"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -5625,36 +5631,36 @@
       <entryLinks>
         <entryLink id="c92c-c104-f6cd-c2e5" name="Turret-Mounted Light AT Gun" hidden="false" collective="false" import="true" targetId="bc28-0208-2b44-a5ac" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daba-753c-636b-a1dd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bd7-08b8-f815-720c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daba-753c-636b-a1dd" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bd7-08b8-f815-720c" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="c705-7965-1df4-6848" name="Coaxial MMG" hidden="false" collective="false" import="true" targetId="cfd8-d421-3cd2-ab75" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38e4-b8bf-5c00-c244" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9956-1ce7-b813-c7f1" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38e4-b8bf-5c00-c244" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9956-1ce7-b813-c7f1" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="bb38-bef0-1b01-af99" name="360-Degree Pintle-Mounted HMG" hidden="false" collective="false" import="true" targetId="313c-cc03-e580-126f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7eec-7545-1f36-33e2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7eec-7545-1f36-33e2" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
           </costs>
         </entryLink>
         <entryLink id="2e39-9aad-26a1-337b" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2a94-104d-fb11-aa76" name="M20 Scout Car" hidden="false" collective="false" import="true" type="unit">
@@ -5677,13 +5683,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2a94-104d-fb11-aa76" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2a94-104d-fb11-aa76" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -5692,37 +5698,37 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d42-37cc-51de-342c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="045b-98c5-2974-ff2d" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d42-37cc-51de-342c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="045b-98c5-2974-ff2d" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="6e1a-374a-70b2-314e" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="0c39-baf3-5f68-819b" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="cd5d-8101-6b33-4a19">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="471f-1ae3-ca4a-944d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d69-7c82-a222-d026" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="471f-1ae3-ca4a-944d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d69-7c82-a222-d026" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="cd5d-8101-6b33-4a19" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="64.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="64"/>
               </costs>
             </entryLink>
             <entryLink id="ce8c-7ee6-d87b-86f5" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="80.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="80"/>
               </costs>
             </entryLink>
             <entryLink id="811c-d190-0068-e91d" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="96.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="96"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -5731,25 +5737,25 @@
       <entryLinks>
         <entryLink id="dafb-8101-8517-56c6" name="360-Degree Pintle-Mounted HMG" hidden="false" collective="false" import="true" targetId="313c-cc03-e580-126f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cf4-0b52-532d-d8ef" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="342e-738e-22f9-434f" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cf4-0b52-532d-d8ef" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="342e-738e-22f9-434f" type="min"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
           </costs>
         </entryLink>
         <entryLink id="d9ab-4420-fc5c-2bcf" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b239-3fcf-830c-7147" name="M4/M5 Artillery Tractor" hidden="false" collective="false" import="true" type="unit">
@@ -5765,28 +5771,28 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="f4f8-ae4c-87d9-6f2c" name="New CategoryLink" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
+        <categoryLink id="f4f8-ae4c-87d9-6f2c" name="Tows" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="0191-a98a-96e9-b0f5" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="06d0-499e-4d13-0713">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0994-4323-4711-d655" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4842-afd4-95f6-e42e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0994-4323-4711-d655" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4842-afd4-95f6-e42e" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="5d2c-24eb-8b72-6a79" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
               </costs>
             </entryLink>
             <entryLink id="aa13-855c-b5a9-8337" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="18.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="18"/>
               </costs>
             </entryLink>
             <entryLink id="06d0-499e-4d13-0713" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="12.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="12"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -5795,15 +5801,15 @@
       <entryLinks>
         <entryLink id="8bf2-f7de-44b8-23b4" name="360-Degree Pintle-Mounted HMG" hidden="false" collective="false" import="true" targetId="313c-cc03-e580-126f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="051b-da97-c1c1-570d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="051b-da97-c1c1-570d" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
           </costs>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="948d-c84a-c814-7856" name="Armored Officer" hidden="false" collective="false" import="true" type="unit">
@@ -5812,8 +5818,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -5822,23 +5828,23 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="4e6d-a634-602a-c560" name="New CategoryLink" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
+        <categoryLink id="4e6d-a634-602a-c560" name="Headquarters" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
         <categoryLink id="d333-eac0-5e5f-77a3" name="Commander" hidden="false" targetId="fb1a-cb93-a427-51cf" primary="false"/>
-        <categoryLink id="7724-8619-d241-fa11" name="Armored Officer" hidden="false" targetId="31fe-b631-5c13-5493" primary="false"/>
+        <categoryLink id="7724-8619-d241-fa11" name="US Armored Officer" hidden="false" targetId="31fe-b631-5c13-5493" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="bffe-e754-e969-ee05" name="Rank" hidden="false" collective="false" import="true" defaultSelectionEntryId="25b4-fbf2-a5bc-4d10">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f51-4e11-fb71-ce88" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da88-71dd-090c-c9b3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f51-4e11-fb71-ce88" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da88-71dd-090c-c9b3" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="25b4-fbf2-a5bc-4d10" name="Second Lieutenant" page="147" hidden="false" collective="false" import="true" type="model">
@@ -5853,13 +5859,13 @@
               <entryLinks>
                 <entryLink id="8c73-f09c-4bfd-4f52" name="SMG" hidden="false" collective="false" import="true" targetId="da2f-423c-1523-5126" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d416-967b-88cd-7870" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e11e-82f8-faca-d015" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d416-967b-88cd-7870" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e11e-82f8-faca-d015" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="80.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="80"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f013-cb69-3ded-27ea" name="First Lieutenant" page="147" hidden="false" collective="false" import="true" type="model">
@@ -5874,20 +5880,20 @@
               <entryLinks>
                 <entryLink id="bb5b-280f-3be2-5c4f" name="SMG" hidden="false" collective="false" import="true" targetId="da2f-423c-1523-5126" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3e6-07d9-959f-d090" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abef-e21c-0864-90fb" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3e6-07d9-959f-d090" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abef-e21c-0864-90fb" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="105.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="105"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="158d-9acb-36c2-bae8" name="Additional Men" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b8b-d63e-395f-7c93" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b8b-d63e-395f-7c93" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="a680-0cce-00e8-3f85" name="Heavy Infantry" hidden="false" collective="false" import="true" type="model">
@@ -5900,20 +5906,20 @@
               <entryLinks>
                 <entryLink id="5448-f726-4071-7927" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="7cdc-1638-6e4c-f0fa" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf1f-bd64-e10f-182a" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="694a-f7b8-1681-4e3d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf1f-bd64-e10f-182a" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="694a-f7b8-1681-4e3d" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="21.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="21"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1c2f-b0cc-8aba-0200" name="Armored Senior Officer" hidden="false" collective="false" import="true" type="unit">
@@ -5922,8 +5928,8 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -5932,23 +5938,23 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="49ca-9249-65ba-a3e1" name="New CategoryLink" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
+        <categoryLink id="49ca-9249-65ba-a3e1" name="Headquarters" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
         <categoryLink id="1ca2-d572-37cc-c12c" name="Senior Officer" hidden="false" targetId="b14d-60bd-51cb-1c49" primary="false"/>
-        <categoryLink id="6129-cf21-6318-28b2" name="Armored Officer" hidden="false" targetId="31fe-b631-5c13-5493" primary="false"/>
+        <categoryLink id="6129-cf21-6318-28b2" name="US Armored Officer" hidden="false" targetId="31fe-b631-5c13-5493" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="64b6-5549-be0f-b694" name="Additional Men" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45e3-1a53-6425-2b1e" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="065c-7a9a-d627-2663" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45e3-1a53-6425-2b1e" type="min"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="065c-7a9a-d627-2663" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="b553-b255-1e00-c69e" name="Heavy Infantry" page="147" hidden="false" collective="false" import="true" type="model">
@@ -5961,21 +5967,21 @@
               <entryLinks>
                 <entryLink id="3cfb-5529-73e8-a2a3" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="2028-537e-fe2b-8dba" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab36-f41b-e479-cb9b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5802-84c9-5aeb-3e23" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab36-f41b-e479-cb9b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5802-84c9-5aeb-3e23" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="21.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="21"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="8553-71d8-a7ec-6cab" name="Rank" hidden="false" collective="false" import="true" defaultSelectionEntryId="1942-bce1-d0e2-22e2">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4597-7024-88aa-50e2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4609-65b8-9e98-74ae" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4597-7024-88aa-50e2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4609-65b8-9e98-74ae" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="96ee-f86b-e8d3-2e2d" name="Major" page="147" hidden="false" collective="false" import="true" type="model">
@@ -5990,13 +5996,13 @@
               <entryLinks>
                 <entryLink id="30e1-876c-9313-0588" name="SMG" hidden="false" collective="false" import="true" targetId="da2f-423c-1523-5126" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="debb-5932-9e86-ca7d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcb4-3187-40cd-0e19" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="debb-5932-9e86-ca7d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcb4-3187-40cd-0e19" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="180.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="180"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1942-bce1-d0e2-22e2" name="Captain" page="147" hidden="false" collective="false" import="true" type="model">
@@ -6011,20 +6017,20 @@
               <entryLinks>
                 <entryLink id="c8a5-fb77-1851-c489" name="SMG" hidden="false" collective="false" import="true" targetId="da2f-423c-1523-5126" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5360-60a7-43ac-9723" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2673-5015-2f99-4ee0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5360-60a7-43ac-9723" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2673-5015-2f99-4ee0" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="140.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="140"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2dc2-df5f-a47f-ca6e" name="Paragon Officer Slammer Samuels" hidden="false" collective="false" import="true" type="unit">
@@ -6042,9 +6048,9 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3ff8-964d-a685-97b1" name="Senior Officer" hidden="false" targetId="b14d-60bd-51cb-1c49" primary="false"/>
-        <categoryLink id="5705-e4e1-0c9a-07d4" name="New CategoryLink" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="false"/>
+        <categoryLink id="5705-e4e1-0c9a-07d4" name="Headquarters" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="false"/>
         <categoryLink id="0b86-5aae-8e56-1401" name="Paragon Officer" hidden="false" targetId="df35-2027-c9d7-ca2f" primary="false"/>
-        <categoryLink id="57b8-9e51-7bd8-0855" name="New CategoryLink" hidden="false" targetId="be7e-306b-30b5-03b8" primary="true"/>
+        <categoryLink id="57b8-9e51-7bd8-0855" name="Characters" hidden="false" targetId="be7e-306b-30b5-03b8" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1763-dc55-53f3-0fb1" name="Tesla Gauntlet" hidden="false" collective="false" import="true" type="upgrade">
@@ -6067,20 +6073,20 @@
             <infoLink id="9dd3-2ed7-5785-76b3" name="Tank Hunters" hidden="false" targetId="c707-cf7b-113b-507b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="618b-5ee7-771c-b3fa" name="Heavy Tesla Rifle" hidden="false" collective="false" import="true" targetId="24b7-7446-6056-7e69" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88da-581b-30d4-3ebc" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6107-fd3f-4233-9c15" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88da-581b-30d4-3ebc" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6107-fd3f-4233-9c15" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="155.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="155"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="449c-0122-b855-c36e" name="Paragon Squad" hidden="false" collective="false" import="true" type="unit">
@@ -6088,18 +6094,18 @@
         <categoryLink id="48a2-16ae-1dcd-22fa" name="Airborne, Firefly, Paragon, and Paragon Support squads" hidden="false" targetId="3d5f-584d-0742-f29d" primary="false"/>
         <categoryLink id="3837-39ce-9468-52d0" name="Heavy Infantry, Paragon, and Paragon Support squads" hidden="false" targetId="9cf3-0bc0-7974-b411" primary="false"/>
         <categoryLink id="155a-a5c9-feb3-c4ec" name="Marine, Paragon, Paragon Support squads only" hidden="false" targetId="2fa0-e678-ad52-d310" primary="false"/>
-        <categoryLink id="5bdf-14c0-dff8-ae72" name="New CategoryLink" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
+        <categoryLink id="5bdf-14c0-dff8-ae72" name="Infantry Squads" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="0ebe-0789-8f4b-84cc" name="Squad Members" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e5e-f103-ebdf-475a" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5eb9-d99b-f847-f142" type="max"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e5e-f103-ebdf-475a" type="min"/>
+            <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5eb9-d99b-f847-f142" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="588d-113a-4812-dfd4" name="&apos;Grease&apos;" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89c2-6a4e-34c0-35eb" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89c2-6a4e-34c0-35eb" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="6f79-0afe-99c1-6987" name="Strong" hidden="false" targetId="3425-a896-a3bb-8bef" type="rule"/>
@@ -6111,18 +6117,18 @@
               <entryLinks>
                 <entryLink id="50a9-d758-b256-32f3" name="Shotgun" hidden="false" collective="false" import="true" targetId="fc9e-d657-62e3-2a8d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4acf-7567-5e8b-da28" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4230-e733-0d87-badd" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4acf-7567-5e8b-da28" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4230-e733-0d87-badd" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2135-1ac4-49ac-af76" name="Max &apos;The Hachet&apos; Ashby" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eba-da7f-cf10-d0a2" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eba-da7f-cf10-d0a2" type="max"/>
               </constraints>
               <profiles>
                 <profile id="0785-6bcc-5e2b-7361" name="Axe" hidden="false" typeId="6f79-864b-5586-5191" typeName="Weapon">
@@ -6144,18 +6150,18 @@
               <entryLinks>
                 <entryLink id="860b-b37d-ebcf-90b6" name="SMG" hidden="false" collective="false" import="true" targetId="da2f-423c-1523-5126" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28aa-9f6b-3445-a85b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9e5-701b-04f5-7ec9" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28aa-9f6b-3445-a85b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9e5-701b-04f5-7ec9" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="217a-e891-d8f7-fc73" name="John &apos;Sue&apos; Walton" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b79e-dbe1-aea5-27dd" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b79e-dbe1-aea5-27dd" type="max"/>
               </constraints>
               <rules>
                 <rule id="5408-fe69-14a7-a957" name="Dual SMGs" hidden="false">
@@ -6174,18 +6180,18 @@
               <entryLinks>
                 <entryLink id="3632-1433-5ed3-e49a" name="SMG" hidden="false" collective="false" import="true" targetId="da2f-423c-1523-5126" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a930-8477-00ca-10d1" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36b8-2657-1afb-78e1" type="min"/>
+                    <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a930-8477-00ca-10d1" type="max"/>
+                    <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36b8-2657-1afb-78e1" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7737-bd59-2307-4ab0" name="Sadao Munemori" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ede6-2198-97d4-a83d" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ede6-2198-97d4-a83d" type="max"/>
               </constraints>
               <profiles>
                 <profile id="2249-7e87-664c-0f26" name="Sword" hidden="false" typeId="6f79-864b-5586-5191" typeName="Weapon">
@@ -6205,12 +6211,12 @@
                 <infoLink id="f577-78a5-72dc-bdee" name="Tough" hidden="false" targetId="a177-5aaa-1b45-b6e2" type="rule"/>
               </infoLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a762-3954-21d9-b8fb" name="Cpl Zigmont &apos;The Monster&apos; Macrathus (NCO)" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c0c-8a54-271b-7ab3" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c0c-8a54-271b-7ab3" type="max"/>
               </constraints>
               <rules>
                 <rule id="0a9c-4694-600e-2499" name="NCO" hidden="false">
@@ -6228,18 +6234,18 @@
               <entryLinks>
                 <entryLink id="63bc-bda4-8d4a-6e14" name="Automatic Rifle" hidden="false" collective="false" import="true" targetId="5a99-78b7-12a9-0f4c" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a4e-4fe2-2f77-c92e" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="281a-8c96-9474-048c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a4e-4fe2-2f77-c92e" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="281a-8c96-9474-048c" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="adfd-05d0-a6c1-5f66" name="Sgt Abraham &apos;Hammer&apos; Marshall (NCO)" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d784-d9c6-6f15-ee55" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d784-d9c6-6f15-ee55" type="max"/>
               </constraints>
               <rules>
                 <rule id="a9d0-c30d-c9bc-dbff" name="NCO" hidden="false">
@@ -6256,20 +6262,20 @@
               <entryLinks>
                 <entryLink id="1b06-f4f4-3473-8b35" name="Heavy Tesla Rifle" hidden="false" collective="false" import="true" targetId="24b7-7446-6056-7e69" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="200a-057a-2536-aa07" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c22-b26a-62b7-8cc8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="200a-057a-2536-aa07" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c22-b26a-62b7-8cc8" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="70.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="70"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9dad-56eb-604e-147b" name="M8 Grizzly ARV" hidden="false" collective="false" import="true" type="unit">
@@ -6280,26 +6286,26 @@
       </infoLinks>
       <categoryLinks>
         <categoryLink id="2a63-17f1-059e-0152" name="Walkers" hidden="false" targetId="2161-15bd-f8a3-750b" primary="true"/>
-        <categoryLink id="fa06-f962-8852-cc49" name="Tank, Tank Destroyer, Medium Walkers, and Heavy Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
+        <categoryLink id="fa06-f962-8852-cc49" name="Tank, Tank Destroyer, Walkers" hidden="false" targetId="b4ef-18ac-e4b0-39cf" primary="false"/>
         <categoryLink id="46e6-1a56-c949-41a8" name="Tank, Tank Destroyer, Assault Gun, Walker, and Armoured Car" hidden="false" targetId="c1e2-bbe0-922c-ff35" primary="false"/>
         <categoryLink id="4fa8-296a-e9ad-1951" name="Tank, Tank Destroyer, Assault Gun, Walker, Self-Propelled Artillery, Anti-Aircraft Vehicle, Armoured Car" hidden="false" targetId="2223-b0fe-f380-0b0d" primary="false"/>
-        <categoryLink id="0263-4723-9b4a-a65b" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Medium Walkers, and Heavy Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
+        <categoryLink id="0263-4723-9b4a-a65b" name="Tank, Tank Destroyer, AA Vehicles, Self-Propelled Artillery, Walkers" hidden="false" targetId="45ac-0cd1-0fd0-edd3" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="dede-e597-fb42-d79a" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="1e16-2162-daf1-fb90">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="558d-dd39-be97-381c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf8f-599b-618c-e85a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="558d-dd39-be97-381c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf8f-599b-618c-e85a" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="2dfa-8d9d-e854-5901" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="132.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="132"/>
               </costs>
             </entryLink>
             <entryLink id="1e16-2162-daf1-fb90" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="115.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="115"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -6308,19 +6314,19 @@
       <entryLinks>
         <entryLink id="2f95-4977-58b8-00b2" name="Fist" hidden="false" collective="true" import="true" targetId="8503-f9cf-c544-aa05" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ddb-ba7e-9e0a-9720" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8159-6449-2339-6dfb" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ddb-ba7e-9e0a-9720" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8159-6449-2339-6dfb" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="4be1-85d8-af81-e074" name="Pintle-Mounted Forward-Facing HMG" hidden="false" collective="false" import="true" targetId="0fde-b247-5ea6-a771" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f396-d561-f79d-0d20" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="188f-8476-6e34-eac6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f396-d561-f79d-0d20" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="188f-8476-6e34-eac6" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="73c2-d4c0-de52-8aeb" name="M8A3 Tesla Scout" hidden="false" collective="false" import="true" type="unit">
@@ -6342,13 +6348,13 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="73c2-d4c0-de52-8aeb" type="atLeast"/>
+                    <condition field="selections" scope="force" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="73c2-d4c0-de52-8aeb" type="atLeast"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba3f-311f-cdef-2044" type="atLeast"/>
+                        <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1490-84ec-67d8-0dae" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -6357,32 +6363,32 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e3ac-822e-7024-492d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="65e1-4b7e-3019-2b05" type="max"/>
+            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e3ac-822e-7024-492d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="65e1-4b7e-3019-2b05" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="f552-1d40-d757-874e" name="Radio Network" hidden="false" targetId="0727-1eba-1222-74fd" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="1ab6-2260-2520-c5f3" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="65d1-845c-eb05-9d47">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d66-5fb2-7947-d43c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="497b-b0e3-3e1f-73a9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d66-5fb2-7947-d43c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="497b-b0e3-3e1f-73a9" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="5ce3-b080-86d4-5e15" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="145.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="145"/>
               </costs>
             </entryLink>
             <entryLink id="65d1-845c-eb05-9d47" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="118.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="118"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -6391,60 +6397,60 @@
       <entryLinks>
         <entryLink id="ed53-5b95-6cd6-4cc9" name="Turret-Mounted M21 Light Tesla Cannon" hidden="false" collective="false" import="true" targetId="2a27-8bb6-79a1-2407" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24da-a9d8-1b5f-ae5c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaad-dc71-e674-e350" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24da-a9d8-1b5f-ae5c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaad-dc71-e674-e350" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="67e6-614a-ee4b-6dc9" name="360-Degree Pintle-Mounted HMG" hidden="false" collective="false" import="true" targetId="313c-cc03-e580-126f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc00-d43a-97ac-f8b6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc00-d43a-97ac-f8b6" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
           </costs>
         </entryLink>
         <entryLink id="ced8-f78d-8c5d-a2ca" name="Command Vehicle" hidden="true" collective="false" import="true" targetId="61b2-f1f9-b980-c0c1" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="4fcf-76d8-8f5b-ffa8" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b65a-7867-c905-626e" name="M32 ARV" publicationId="9a47-ac76-pubN66291" page="" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="b65a-7867-c905-626e" name="M32 ARV" publicationId="9a47-ac76-pubN66291" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="6d26-7aa2-8c74-42ab" name="ARV" hidden="false" targetId="989b-f1c2-debc-660a" type="rule"/>
         <infoLink id="fce0-fe03-e7f7-8c76" name="Medium Tank" hidden="false" targetId="f945-ed13-872d-e38b" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="55ca-5f5d-3225-5f62" name="New CategoryLink" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
+        <categoryLink id="55ca-5f5d-3225-5f62" name="Tows" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="0b48-8483-6989-839b" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="13ff-a695-d5ee-3850">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b0d-8b14-8a67-dc77" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de9d-1f26-e80b-55a7" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b0d-8b14-8a67-dc77" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de9d-1f26-e80b-55a7" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="a659-6445-6028-6748" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="96.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="96"/>
               </costs>
             </entryLink>
             <entryLink id="6fb6-2033-758d-ddee" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="115.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="115"/>
               </costs>
             </entryLink>
             <entryLink id="13ff-a695-d5ee-3850" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="77.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="77"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -6453,13 +6459,13 @@
       <entryLinks>
         <entryLink id="3424-cc09-4be8-1f19" name="Hull-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="f3d9-1a0f-0031-e8c7" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8950-457d-bf8b-3485" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abbf-b2bb-8fc9-8900" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8950-457d-bf8b-3485" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abbf-b2bb-8fc9-8900" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b730-6635-cc1f-914e" name="Tank Recovery Tractor" hidden="false" collective="false" import="true" type="unit">
@@ -6478,24 +6484,24 @@
         <infoLink id="eb55-2992-a08e-93a2" name="ARV" hidden="false" targetId="989b-f1c2-debc-660a" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0713-3438-ee9b-4f00" name="New CategoryLink" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
+        <categoryLink id="0713-3438-ee9b-4f00" name="Tows" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="4701-be66-0c12-06a5" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="4e86-45c4-4c87-1097">
           <entryLinks>
             <entryLink id="1926-fc54-d8c0-d8f8" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="12.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="12"/>
               </costs>
             </entryLink>
             <entryLink id="b2eb-236d-6a7a-eee2" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="1.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="1"/>
               </costs>
             </entryLink>
             <entryLink id="4e86-45c4-4c87-1097" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="10"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -6504,21 +6510,21 @@
       <entryLinks>
         <entryLink id="322e-0351-4f81-b6bc" name="Pintle-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="3384-54f8-488f-d217" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71e4-b8f7-87f8-7871" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71e4-b8f7-87f8-7871" type="max"/>
           </constraints>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
           </costs>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8583-53c7-63e8-00c6" name="Forward Artillery Observer" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="a975-cc8b-3b7a-e35b" name="Forward Artillery Observer" hidden="false" targetId="1f3d-c608-4cb7-2ec0" primary="false"/>
-        <categoryLink id="d525-38b6-66b8-14cc" name="New CategoryLink" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
+        <categoryLink id="d525-38b6-66b8-14cc" name="Headquarters" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
         <categoryLink id="d357-cef2-bc12-0100" name="Forward Observer" hidden="false" targetId="c048-dfb7-583d-2e79" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -6526,28 +6532,28 @@
           <modifierGroups>
             <modifierGroup>
               <modifiers>
-                <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="100.0">
+                <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="100">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                   </conditions>
                 </modifier>
-                <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="115.0">
+                <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="115">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                   </conditions>
                 </modifier>
               </modifiers>
             </modifierGroup>
           </modifierGroups>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5654-e7e2-01e5-1942" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a32a-a15c-4458-9092" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5654-e7e2-01e5-1942" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a32a-a15c-4458-9092" type="max"/>
           </constraints>
           <selectionEntryGroups>
             <selectionEntryGroup id="f885-a6ed-76c6-86d2" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9a9b-370b-25ff-dc43">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae79-4e68-df5a-3195" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97f7-d297-fdc3-2815" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae79-4e68-df5a-3195" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97f7-d297-fdc3-2815" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="5b61-6799-7b2d-15c3" name="Pistol" hidden="false" collective="false" import="true" targetId="d7b1-e557-88f6-1ac4" type="selectionEntry"/>
@@ -6557,15 +6563,15 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="b24c-d365-4ad2-f628" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="884a-42c8-30f5-5b8e">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6cc-870f-8d8f-3621" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e1e-615e-6cfa-1b5c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6cc-870f-8d8f-3621" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e1e-615e-6cfa-1b5c" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="f6d2-7f62-6935-9cc1" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry"/>
@@ -6574,21 +6580,21 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="b355-3f99-a2ad-7f86" name="Additional Men" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0008-c015-e9be-3a15" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0008-c015-e9be-3a15" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="8853-a525-192f-e9c7" name="Soldier" page="147" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -6597,8 +6603,8 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="607a-c43d-59f5-bb08" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="7b3c-fcd2-d040-3e12">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b51b-76dd-920b-4594" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="004c-4e1b-edc5-9a32" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b51b-76dd-920b-4594" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="004c-4e1b-edc5-9a32" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="fa86-995f-df09-884e" name="Pistol" hidden="false" collective="false" import="true" targetId="d7b1-e557-88f6-1ac4" type="selectionEntry"/>
@@ -6608,20 +6614,20 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fd1c-4ace-7bff-ec1d" name="Forward Air Observer" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="d727-4c85-ff4c-4a89" name="Forward Air Observer" hidden="false" targetId="1a15-5468-fc36-e232" primary="false"/>
-        <categoryLink id="33cb-777f-c4d6-96e1" name="New CategoryLink" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
+        <categoryLink id="33cb-777f-c4d6-96e1" name="Headquarters" hidden="false" targetId="1ca2-f9d6-c173-2664" primary="true"/>
         <categoryLink id="bd1c-c815-11f0-ab61" name="Forward Observer" hidden="false" targetId="c048-dfb7-583d-2e79" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -6629,28 +6635,28 @@
           <modifierGroups>
             <modifierGroup>
               <modifiers>
-                <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="75.0">
+                <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="75">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                   </conditions>
                 </modifier>
-                <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="90.0">
+                <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="90">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                   </conditions>
                 </modifier>
               </modifiers>
             </modifierGroup>
           </modifierGroups>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c88-8492-8450-13da" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a066-b2e8-ca66-4858" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c88-8492-8450-13da" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a066-b2e8-ca66-4858" type="max"/>
           </constraints>
           <selectionEntryGroups>
             <selectionEntryGroup id="d135-a3af-8952-ec50" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="bc58-ea05-7155-c760">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b144-5114-ea3e-cf1b" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d918-8df7-898b-a3d9" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b144-5114-ea3e-cf1b" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d918-8df7-898b-a3d9" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="d4ce-43a9-a29e-8f9d" name="Pistol" hidden="false" collective="false" import="true" targetId="d7b1-e557-88f6-1ac4" type="selectionEntry"/>
@@ -6660,15 +6666,15 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="c3c3-1798-a023-37e5" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="55cb-f165-3ee7-dedd">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3b8-c7fe-b933-1610" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="882c-6ddb-3463-aa8e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3b8-c7fe-b933-1610" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="882c-6ddb-3463-aa8e" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="bf20-ccd2-ad7d-c722" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry"/>
@@ -6677,21 +6683,21 @@
         </selectionEntryGroup>
         <selectionEntryGroup id="048d-c124-275a-62db" name="Additional Men" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfbe-19e9-deab-89e8" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfbe-19e9-deab-89e8" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="5946-39a3-4867-58dd" name="Soldier" page="147" hidden="false" collective="false" import="true" type="model">
               <modifierGroups>
                 <modifierGroup>
                   <modifiers>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="10">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="020b-0c80-419b-6391" type="greaterThan"/>
                       </conditions>
                     </modifier>
-                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13.0">
+                    <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="13">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
+                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-6911-51f6-d7a2" type="greaterThan"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -6700,8 +6706,8 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="3d88-0053-6752-2d6c" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="e053-dfd3-82a9-6dd8">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2555-230d-d312-8f25" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3eda-0d74-d082-4537" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2555-230d-d312-8f25" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3eda-0d74-d082-4537" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="56ca-8577-3c14-0baa" name="Pistol" hidden="false" collective="false" import="true" targetId="d7b1-e557-88f6-1ac4" type="selectionEntry"/>
@@ -6711,14 +6717,14 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c910-0584-887e-c4cc" name="Rangers Squad" hidden="false" collective="false" import="true" type="unit">
@@ -6727,47 +6733,47 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="d009-b54f-a9c0-dea3" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="f2fe-1cca-41ad-863f" name="New CategoryLink" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
+        <categoryLink id="f2fe-1cca-41ad-863f" name="Infantry Squads" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5afd-1381-92fb-dd28" name="Anti-Tank Grenades" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="2.0">
+            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="2">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6406-821e-5036-23e2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6406-821e-5036-23e2" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="7e21-1d76-4e9e-091a" name="Tank Hunters" hidden="false" targetId="c707-cf7b-113b-507b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="06ec-2968-04da-5b9a" name="Squad Members" hidden="false" collective="false" import="true" defaultSelectionEntryId="f693-542e-dbec-19ce">
           <constraints>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44f6-5e90-d9ec-a8e3" type="min"/>
-            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f88-468f-9b82-1e6b" type="max"/>
+            <constraint field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44f6-5e90-d9ec-a8e3" type="min"/>
+            <constraint field="selections" scope="parent" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f88-468f-9b82-1e6b" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="c97a-60f7-c4c1-0a10" name="NCO" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="298d-8070-d071-312e" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a814-3220-bc69-12f3" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="298d-8070-d071-312e" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a814-3220-bc69-12f3" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="64e3-27b5-7531-a85a" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -6775,26 +6781,26 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="22d1-1d7e-b5ae-c4c1" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="1f0c-a813-9cd2-91dd">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec58-302c-ac24-d85d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa1d-fa65-bb50-195f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec58-302c-ac24-d85d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa1d-fa65-bb50-195f" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="1f0c-a813-9cd2-91dd" name="Rifle" hidden="false" collective="false" import="true" targetId="69b8-002c-ef16-c6e4" type="selectionEntry"/>
                     <entryLink id="4a0b-1ddd-fee3-9347" name="SMG" hidden="false" collective="false" import="true" targetId="da2f-423c-1523-5126" type="selectionEntry">
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3"/>
                       </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79d8-6d8c-03c4-f54e" name="Soldier with BAR" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8028-c5c5-3279-e923" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8028-c5c5-3279-e923" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="6c6c-731e-e7b9-2bb7" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -6802,21 +6808,21 @@
               <entryLinks>
                 <entryLink id="4812-1c79-f890-e61e" name="Automatic Rifle" hidden="false" collective="false" import="true" targetId="1efc-f6d3-abb7-0876" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2542-42a9-5f61-7aa9" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0a6-f644-ad0a-03ff" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2542-42a9-5f61-7aa9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0a6-f644-ad0a-03ff" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="5"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f693-542e-dbec-19ce" name="Soldier with Rifle" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1695-7457-a71e-f8a3" type="max"/>
+                <constraint field="selections" scope="parent" value="11" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1695-7457-a71e-f8a3" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="35f9-3c45-de09-e88e" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -6824,18 +6830,18 @@
               <entryLinks>
                 <entryLink id="9496-cb18-597a-6c6d" name="Rifle" hidden="false" collective="false" import="true" targetId="0a1a-55ad-a310-3cdc" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f6e-ac34-5432-a2a9" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5499-83f8-631f-53a7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f6e-ac34-5432-a2a9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5499-83f8-631f-53a7" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d3bf-bbf2-225d-7ad4" name="Soldier with SMG" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0ac-b520-b89d-f113" type="max"/>
+                <constraint field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0ac-b520-b89d-f113" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="c1bb-fc90-7c6c-12ab" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -6843,28 +6849,28 @@
               <entryLinks>
                 <entryLink id="7d77-d3ab-8ac0-5c02" name="SMG" hidden="false" collective="false" import="true" targetId="0fae-2704-edd4-5dd1" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8a1-5fd9-cdf8-9f89" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb75-f73e-74cc-80c0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8a1-5fd9-cdf8-9f89" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb75-f73e-74cc-80c0" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="3"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69a7-180f-e34c-ac19" name="Soldier with Grenade Launcher" hidden="false" collective="false" import="true" type="model">
               <modifiers>
-                <modifier type="decrement" field="275c-a032-c9df-f633" value="1.0">
+                <modifier type="decrement" field="275c-a032-c9df-f633" value="1">
                   <conditions>
-                    <condition field="selections" scope="c910-0584-887e-c4cc" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e181-034e-89c4-c95c" type="greaterThan"/>
+                    <condition field="selections" scope="c910-0584-887e-c4cc" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e181-034e-89c4-c95c" type="greaterThan"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="275c-a032-c9df-f633" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="275c-a032-c9df-f633" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="0d8f-312d-e8af-4eb5" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -6872,21 +6878,21 @@
               <entryLinks>
                 <entryLink id="2561-5398-8e1e-afe9" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e128-57af-2dc7-c91e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aa7-cb0a-9e59-dcde" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e2d-aad9-c5af-87ff" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aa7-cb0a-9e59-dcde" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e2d-aad9-c5af-87ff" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d6af-8a3b-d0a2-1c64" name="Soldier with LMG" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7cc-c6b8-48ba-d8a5" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7cc-c6b8-48ba-d8a5" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="777e-0ba9-bd4f-b315" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -6894,16 +6900,16 @@
               <entryLinks>
                 <entryLink id="efe7-6fe8-38eb-e112" name="LMG" hidden="false" collective="false" import="true" targetId="6dc4-67a2-757e-5aa9" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="145f-e51e-901a-1df3" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ffa-9195-8a31-7e3c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="145f-e51e-901a-1df3" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ffa-9195-8a31-7e3c" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="13"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -6912,31 +6918,31 @@
           <entryLinks>
             <entryLink id="7f77-247d-cda8-d3aa" name="Rifle Grenade" hidden="false" collective="false" import="true" targetId="4492-e0f5-5aa1-5c8a" type="selectionEntry">
               <modifiers>
-                <modifier type="decrement" field="5df3-041c-b64d-fb9f" value="1.0">
+                <modifier type="decrement" field="5df3-041c-b64d-fb9f" value="1">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="69a7-180f-e34c-ac19" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="69a7-180f-e34c-ac19" type="greaterThan"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5df3-041c-b64d-fb9f" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5df3-041c-b64d-fb9f" type="max"/>
               </constraints>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="20"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fab0-31bb-75e7-8d6f" name="Firefly Jump Infantry Squad" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="fc99-d029-3815-9e1d" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+            <condition field="selections" scope="fc99-d029-3815-9e1d" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -6944,40 +6950,40 @@
         <infoLink id="9afb-0da0-e3e0-780d" name="Flight" hidden="false" targetId="e8fc-b495-4724-e2fd" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="50a4-8d74-d0a6-f893" name="New CategoryLink" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
+        <categoryLink id="50a4-8d74-d0a6-f893" name="Infantry Squads" hidden="false" targetId="360a-867e-e501-63b2" primary="true"/>
         <categoryLink id="c94f-6de1-ad6c-d3e2" name="Airborne, Firefly, Paragon, and Paragon Support squads" hidden="false" targetId="3d5f-584d-0742-f29d" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e86a-3c9e-5d89-e8f8" name="Anti-Tank Grenades" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="2.0">
+            <modifier type="increment" field="d66a-aa5a-74b9-e93a" value="2">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fee-067f-5f90-c18b" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fee-067f-5f90-c18b" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="df6e-e008-2faf-b8c8" name="Tank Hunters" hidden="false" targetId="c707-cf7b-113b-507b" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="c8fe-29e2-652c-e859" name="Squad Members" hidden="false" collective="false" import="true" defaultSelectionEntryId="a603-5849-074b-aa43">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c29c-a33d-8aea-eda0" type="min"/>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ee8-a7c0-568d-f007" type="max"/>
+            <constraint field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c29c-a33d-8aea-eda0" type="min"/>
+            <constraint field="selections" scope="parent" value="10" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ee8-a7c0-568d-f007" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="8acc-d432-c566-b08a" name="NCO" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e64-1767-41f0-d1a8" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea0b-2d5d-0a6f-1f47" type="min"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e64-1767-41f0-d1a8" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea0b-2d5d-0a6f-1f47" type="min"/>
               </constraints>
               <infoLinks>
                 <infoLink id="fa9c-f72d-a6af-0f02" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -6985,21 +6991,21 @@
               <entryLinks>
                 <entryLink id="bbaa-e660-fbd3-4824" name="SMG" hidden="false" collective="false" import="true" targetId="0fae-2704-edd4-5dd1" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4e2-ca05-48e5-c268" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06b2-19d1-22ae-a664" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4e2-ca05-48e5-c268" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06b2-19d1-22ae-a664" type="min"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="40.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="40"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="18.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="18"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a603-5849-074b-aa43" name="Soldier with SMG" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a940-282a-ac09-cbd0" type="max"/>
+                <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a940-282a-ac09-cbd0" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="25d9-3c11-65d8-bef7" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -7007,18 +7013,18 @@
               <entryLinks>
                 <entryLink id="1cd3-f46a-9d01-b9b5" name="SMG" hidden="false" collective="false" import="true" targetId="0fae-2704-edd4-5dd1" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4792-6374-a73f-19b6" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b571-81dc-2507-59e1" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4792-6374-a73f-19b6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b571-81dc-2507-59e1" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="18.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="18"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4849-ff8b-0e68-7b13" name="Soldier with BAR" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bd0-b412-67d6-1c05" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bd0-b412-67d6-1c05" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="7647-c644-bdc2-2901" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -7026,21 +7032,21 @@
               <entryLinks>
                 <entryLink id="3ba2-4c4f-829a-370c" name="Automatic Rifle" hidden="false" collective="false" import="true" targetId="1efc-f6d3-abb7-0876" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32a1-a4bd-c6c3-9b7d" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff9c-69ad-1ac2-831d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32a1-a4bd-c6c3-9b7d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff9c-69ad-1ac2-831d" type="min"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="2.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="2"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="18.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="18"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53d1-2554-8c7a-55c6" name="Soldier with Flamethrower" hidden="false" collective="false" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e05c-ef72-6574-0e3e" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e05c-ef72-6574-0e3e" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="3cca-0d85-1c86-053e" name="Veteran" hidden="false" targetId="0f37-68ae-dd72-d2dd" type="profile"/>
@@ -7048,76 +7054,76 @@
               <entryLinks>
                 <entryLink id="0361-f5d2-4dae-cbaa" name="Flamethrower (Infantry)" hidden="false" collective="false" import="true" targetId="bfcf-2c7b-f259-66e8" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0aab-690c-858a-70a1" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf5a-19c3-3e6c-7d87" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0aab-690c-858a-70a1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf5a-19c3-3e6c-7d87" type="min"/>
                   </constraints>
                   <costs>
-                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="40.0"/>
+                    <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="40"/>
                   </costs>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="18.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="18"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>
     <entryLink id="e911-878d-c8e9-b3ae" name="2 1/2 Ton Truck" hidden="false" collective="false" import="true" targetId="4ff5-87fb-a4b7-cbab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b87b-de52-5754-462d" name="New CategoryLink" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="false"/>
-        <categoryLink id="a563-b62f-dcc7-d459" name="New CategoryLink" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
+        <categoryLink id="b87b-de52-5754-462d" name="Transports" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="false"/>
+        <categoryLink id="a563-b62f-dcc7-d459" name="Tows" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cbac-4080-c53d-ef57" name="2 1/2 Ton Truck" hidden="false" collective="false" import="true" targetId="4ff5-87fb-a4b7-cbab" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1040-df01-36c1-7647" name="New CategoryLink" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="true"/>
+        <categoryLink id="1040-df01-36c1-7647" name="Transports" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c554-c10f-e152-2937" name="Jeep" hidden="false" collective="false" import="true" targetId="b546-1403-a9b7-12b2" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="aa65-ac79-07de-d9f0" name="New CategoryLink" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="true"/>
+        <categoryLink id="aa65-ac79-07de-d9f0" name="Transports" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="776e-d92d-284e-ed54" name="Jeep" hidden="false" collective="false" import="true" targetId="b546-1403-a9b7-12b2" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ebde-6c1f-cf86-4dcf" name="New CategoryLink" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
+        <categoryLink id="ebde-6c1f-cf86-4dcf" name="Tows" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cbfd-6618-9420-9d72" name="Dodge 3/4 Ton" hidden="false" collective="false" import="true" targetId="7aaa-b1f8-d644-80bf" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8744-3ae2-5e31-7315" name="New CategoryLink" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="true"/>
+        <categoryLink id="8744-3ae2-5e31-7315" name="Transports" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b83b-d840-33f2-55b9" name="Dodge 3/4 Ton" hidden="false" collective="false" import="true" targetId="7aaa-b1f8-d644-80bf" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7eeb-f570-8389-09e6" name="New CategoryLink" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
+        <categoryLink id="7eeb-f570-8389-09e6" name="Tows" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a600-5ba5-456b-04ec" name="M3 Half-Track" hidden="false" collective="false" import="true" targetId="868e-0d23-e9b2-efd2" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b0ea-37a7-3dee-ac6b" name="New CategoryLink" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="true"/>
+        <categoryLink id="b0ea-37a7-3dee-ac6b" name="Transports" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3c9c-a564-073b-1b6b" name="M3 Half-Track" hidden="false" collective="false" import="true" targetId="868e-0d23-e9b2-efd2" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9117-a4a1-3e2d-9997" name="New CategoryLink" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
+        <categoryLink id="9117-a4a1-3e2d-9997" name="Tows" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="41f3-94fe-7e40-7718" name="LVT-3/LVT-4/LVT(A)-5 Amphibious Vehicle" hidden="false" collective="false" import="true" targetId="9536-5a7b-abaf-2c9a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="570e-3ad7-f167-b896" name="New CategoryLink" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="true"/>
+        <categoryLink id="570e-3ad7-f167-b896" name="Transports" hidden="false" targetId="a60d-df71-bfcc-66c4" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="fb98-6e39-3d97-2d36" name="LVT-3/LVT-4/LVT(A)-5 Amphibious Vehicle" hidden="false" collective="false" import="true" targetId="9536-5a7b-abaf-2c9a" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9643-ca1b-5da9-e466" name="New CategoryLink" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
+        <categoryLink id="9643-ca1b-5da9-e466" name="Tows" hidden="false" targetId="f3c7-5675-463e-b566" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -7151,47 +7157,47 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="5db9-a48f-f09e-edbc" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="af00-3f75-d10b-0eca">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b982-0000-aeb0-a64c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f351-1e6b-6dfe-0f37" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b982-0000-aeb0-a64c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f351-1e6b-6dfe-0f37" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="8d5c-9b28-a486-2d1a" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="39.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="39"/>
               </costs>
             </entryLink>
             <entryLink id="3014-acd4-5af3-1010" name="Veteran" hidden="false" collective="false" import="true" targetId="611f-6911-51f6-d7a2" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="47.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="47"/>
               </costs>
             </entryLink>
             <entryLink id="af00-3f75-d10b-0eca" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="31.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="31"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="61c7-4a24-32cf-04c4" name="Pintle Mount" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba74-7481-2797-f2e0" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba74-7481-2797-f2e0" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="14fe-f022-cdcf-4c47" name="Pintle-Mounted Forward-Facing MMG" hidden="false" collective="false" import="true" targetId="3384-54f8-488f-d217" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
               </costs>
             </entryLink>
             <entryLink id="ce12-9b59-33a6-63a5" name="Pintle-Mounted Forward-Facing HMG" hidden="false" collective="false" import="true" targetId="0fde-b247-5ea6-a771" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7aaa-b1f8-d644-80bf" name="Dodge 3/4 Ton" hidden="false" collective="false" import="true" type="unit">
@@ -7209,47 +7215,47 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="1353-bb84-4b7e-a1d7" name="Pintle Mount" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="868d-3cdc-cea0-cc2e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="868d-3cdc-cea0-cc2e" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="df3f-5ae3-ef18-5883" name="360-Degree Pintle-Mounted HMG" hidden="false" collective="false" import="true" targetId="313c-cc03-e580-126f" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
               </costs>
             </entryLink>
             <entryLink id="cbeb-9c6b-f55d-ddd9" name="360-Degree Pintle-Mounted MMG" hidden="false" collective="false" import="true" targetId="7e4e-f831-cd1b-a78d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="02cb-960e-3132-903d" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="3c16-e561-4764-ed69">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d098-1a51-71dd-61f6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7915-31e5-ad2c-94a1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d098-1a51-71dd-61f6" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7915-31e5-ad2c-94a1" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="ea9f-a2eb-7f95-1338" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="31.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="31"/>
               </costs>
             </entryLink>
             <entryLink id="dd7d-3c67-7503-0ad8" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="37.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="37"/>
               </costs>
             </entryLink>
             <entryLink id="3c16-e561-4764-ed69" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b546-1403-a9b7-12b2" name="Jeep" hidden="false" collective="false" import="true" type="unit">
@@ -7258,7 +7264,7 @@
           <modifiers>
             <modifier type="set" field="d07d-e4b6-5527-c556" value="None">
               <conditions>
-                <condition field="selections" scope="b546-1403-a9b7-12b2" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2edb-d97f-1f8a-a591" type="greaterThan"/>
+                <condition field="selections" scope="b546-1403-a9b7-12b2" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2edb-d97f-1f8a-a591" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -7274,47 +7280,47 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="2edb-d97f-1f8a-a591" name="Pintle Mount" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ede-01e5-c962-78fb" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ede-01e5-c962-78fb" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="1ae0-a43f-18bd-6252" name="360-Degree Pintle-Mounted MMG" hidden="false" collective="false" import="true" targetId="7e4e-f831-cd1b-a78d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
               </costs>
             </entryLink>
             <entryLink id="ef07-b7d0-ea55-82b8" name="360-Degree Pintle-Mounted HMG" hidden="false" collective="false" import="true" targetId="313c-cc03-e580-126f" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="8218-a65b-9ef2-9246" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="2fba-497b-192a-a25b">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a36d-03eb-4fc2-f077" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c314-ff34-b562-50fd" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a36d-03eb-4fc2-f077" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c314-ff34-b562-50fd" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="8044-9026-1dda-8781" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="21.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="21"/>
               </costs>
             </entryLink>
             <entryLink id="6fbe-7774-2a3a-de4a" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
               </costs>
             </entryLink>
             <entryLink id="2fba-497b-192a-a25b" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="17.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="17"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="868e-0d23-e9b2-efd2" name="M3 Half-Track" hidden="false" collective="false" import="true" type="unit">
@@ -7337,58 +7343,58 @@
           <selectionEntries>
             <selectionEntry id="72a7-929a-dcfd-ac82" name="Hull-Mounted Left-Arc MMG" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bc3-19d8-4e64-b229" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bc3-19d8-4e64-b229" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="4daa-0872-f378-3ec9" name="MMG" hidden="false" targetId="ab50-4650-872b-78e2" type="profile"/>
               </infoLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="33e9-819e-72a8-7fd1" name="Hull-Mounted Right-Arc MMG" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a99-0e65-9b9e-2d85" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a99-0e65-9b9e-2d85" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="51bc-7e7a-efc3-8fcc" name="MMG" hidden="false" targetId="ab50-4650-872b-78e2" type="profile"/>
               </infoLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d2e3-34f4-90c4-a9a0" name="Pintle-Mounted Rear-Arc MMG" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b91-f985-1560-07a0" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b91-f985-1560-07a0" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="d229-4fca-6535-8c8b" name="MMG" hidden="false" targetId="ab50-4650-872b-78e2" type="profile"/>
               </infoLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="15"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="4392-4e32-2791-12a2" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="c03c-0a39-db7a-dee5">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74bd-4343-57b8-6b05" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07ea-1d45-d8b2-08a9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74bd-4343-57b8-6b05" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07ea-1d45-d8b2-08a9" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="c8f1-52ee-240f-db4d" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="99.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="99"/>
               </costs>
             </entryLink>
             <entryLink id="f1de-f709-7824-acb0" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="119.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="119"/>
               </costs>
             </entryLink>
             <entryLink id="c03c-0a39-db7a-dee5" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="79.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="79"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -7397,13 +7403,13 @@
       <entryLinks>
         <entryLink id="6775-0836-5a9a-22ac" name="360-Degree Pintle-Mounted HMG" hidden="false" collective="false" import="true" targetId="313c-cc03-e580-126f" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="648c-fed1-9baa-9036" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ea5-3f19-1df0-2ffc" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="648c-fed1-9baa-9036" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ea5-3f19-1df0-2ffc" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9536-5a7b-abaf-2c9a" name="LVT-3/LVT-4/LVT(A)-5 Amphibious Vehicle" publicationId="9a47-ac76-pubN65838" page="52" hidden="false" collective="false" import="true" type="unit">
@@ -7425,8 +7431,8 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="b42c-b0f7-efca-962a" name="Model" hidden="false" collective="false" import="true" defaultSelectionEntryId="db67-8ce8-3b40-4ca6">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12e7-b0db-576d-33d4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6096-ea9a-3ead-23d2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12e7-b0db-576d-33d4" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6096-ea9a-3ead-23d2" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="db67-8ce8-3b40-4ca6" name="LVT-3" hidden="false" collective="false" import="true" type="model">
@@ -7444,13 +7450,13 @@
               <entryLinks>
                 <entryLink id="9fce-d553-f626-d848" name="360-Degree Pintle-Mounted MMG" hidden="false" collective="false" import="true" targetId="7e4e-f831-cd1b-a78d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca52-9446-3aca-bb24" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f5d-2e17-373a-9d1b" type="min"/>
+                    <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca52-9446-3aca-bb24" type="max"/>
+                    <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f5d-2e17-373a-9d1b" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a3bc-9368-0320-cd87" name="LVT-4" hidden="false" collective="false" import="true" type="model">
@@ -7473,19 +7479,19 @@
               <entryLinks>
                 <entryLink id="c458-11ed-16f6-5ac1" name="360-Degree Pintle-Mounted MMG" hidden="false" collective="false" import="true" targetId="7e4e-f831-cd1b-a78d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b176-7690-f550-9de5" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d486-0f91-cbef-5245" type="min"/>
+                    <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b176-7690-f550-9de5" type="max"/>
+                    <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d486-0f91-cbef-5245" type="min"/>
                   </constraints>
                 </entryLink>
                 <entryLink id="f817-119e-1360-0079" name="Pintle-Mounted Forward-Facing HMG" hidden="false" collective="false" import="true" targetId="0fde-b247-5ea6-a771" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac75-273d-ee06-f5be" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70ed-5d76-0469-fe5c" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac75-273d-ee06-f5be" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70ed-5d76-0469-fe5c" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="18.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="18"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7d1-186d-1c00-00fd" name="LVT(A)-5" hidden="false" collective="false" import="true" type="model">
@@ -7503,25 +7509,25 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="721b-f7b3-c6c2-5c91" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="1180-c223-fdb2-c9e8">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="867f-026b-deef-3163" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6372-409e-cafa-4508" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="867f-026b-deef-3163" type="min"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6372-409e-cafa-4508" type="max"/>
                   </constraints>
                   <selectionEntries>
                     <selectionEntry id="1180-c223-fdb2-c9e8" name="Light Howitzer and HMG" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98c2-7661-7bae-895d" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98c2-7661-7bae-895d" type="max"/>
                       </constraints>
                       <entryLinks>
                         <entryLink id="1dde-9932-8c94-0fbc" name="360-Degree Pintle-Mounted HMG" hidden="false" collective="false" import="true" targetId="313c-cc03-e580-126f" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a768-cd77-c3ff-7fd7" type="max"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4615-c07f-aece-66b2" type="min"/>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a768-cd77-c3ff-7fd7" type="max"/>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4615-c07f-aece-66b2" type="min"/>
                           </constraints>
                         </entryLink>
                         <entryLink id="031b-f980-86c8-762e" name="Turret-Mounted Light Howitzer" hidden="false" collective="false" import="true" targetId="d837-1e14-a538-69b8" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b969-6654-6755-2a46" type="max"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="625b-fa87-b033-c5f6" type="min"/>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b969-6654-6755-2a46" type="max"/>
+                            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="625b-fa87-b033-c5f6" type="min"/>
                           </constraints>
                           <infoLinks>
                             <infoLink id="035a-39b9-ed38-9c35" name="Gyro-Stabilised" hidden="false" targetId="17c2-1379-b790-b8be" type="rule"/>
@@ -7529,70 +7535,70 @@
                         </entryLink>
                       </entryLinks>
                       <costs>
-                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+                        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
                     <entryLink id="0161-ce3d-c033-2e5d" name="Flamethrower (Vehicle)" hidden="false" collective="false" import="true" targetId="39e6-7490-bb4b-9baa" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e89-594b-42a0-d88a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e89-594b-42a0-d88a" type="max"/>
                       </constraints>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="-15.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="-15"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="a668-5059-1fc9-53af" name="Quality" hidden="false" collective="false" import="true" defaultSelectionEntryId="3df2-2413-52da-cabf">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8374-61b7-eb76-dbf0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d19-5ff3-a624-dcfa" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8374-61b7-eb76-dbf0" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d19-5ff3-a624-dcfa" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="603e-f23a-f8c6-a4ab" name="Regular (Vehicle)" hidden="false" collective="false" import="true" targetId="db47-30f7-6497-9700" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="140.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="140"/>
               </costs>
             </entryLink>
             <entryLink id="b8c1-8e75-87ea-f52c" name="Veteran (Vehicle)" hidden="false" collective="false" import="true" targetId="bf9f-ad2a-55c5-505e" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="168.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="168"/>
               </costs>
             </entryLink>
             <entryLink id="3df2-2413-52da-cabf" name="Inexperienced (Vehicle)" hidden="false" collective="false" import="true" targetId="0eb8-ef2c-f337-579d" type="selectionEntry">
               <costs>
-                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="112.0"/>
+                <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="112"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0.0"/>
+        <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="61b2-f1f9-b980-c0c1" name="Command Vehicle" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d5cc-bea2-96d1-41a9" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aef6-1ef1-fda3-ca76" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2bc6-55f6-2cf0-0029" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d5cc-bea2-96d1-41a9" type="max"/>
+        <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aef6-1ef1-fda3-ca76" type="min"/>
+        <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2bc6-55f6-2cf0-0029" type="max"/>
       </constraints>
       <entryLinks>
         <entryLink id="3b50-4f57-6e98-5662" name="Command Vehicle" hidden="false" collective="false" import="true" targetId="1490-84ec-67d8-0dae" type="selectionEntry">
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="25"/>
           </costs>
         </entryLink>
         <entryLink id="b945-5bd7-8b46-3355" name="Senior Command Vehicle" hidden="false" collective="false" import="true" targetId="ba3f-311f-cdef-2044" type="selectionEntry">
           <costs>
-            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="40.0"/>
+            <cost name="points" typeId="d66a-aa5a-74b9-e93a" value="40"/>
           </costs>
         </entryLink>
       </entryLinks>


### PR DESCRIPTION
Opening as draft to illustrate a problem:

I edited this with NewRecruit editor, and it seems to have touched every single line in the file.

Do the Konflikt47 data maintainers intend to switch to NewRecruit editor,  or should this PR be re-opened from BattleScribe editor, where I assume there would be a much smaller resulting diff.

Alternately, if we wan't to cut over to NewRecruit as the "standard" editor to be used, I'm happy to open new prs on each catalog with no changes other than what NewRecruit does when saving an unchanged file.

Thoughts?